### PR TITLE
Add README with project overview and tech stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,59 @@
+# readingbook-management
+
+読書記録を管理するアプリ。
+
+## 概要
+
+読んだ本のタイトル・著者・感想・読了日などを記録し、自分の読書履歴を管理できるWebアプリケーションです。
+
+## 技術スタック
+
+- **バックエンド**: Ruby / Ruby on Rails
+- **フロントエンド**: Next.js (React / TypeScript)
+- **データベース**: TBD
+- **認証**: TBD
+
+## 主な機能（予定）
+
+- 書籍の登録・編集・削除
+- 読書ステータス管理（未読 / 読書中 / 読了）
+- 感想・メモの記録
+- 読書履歴の一覧・検索
+- 読書統計の表示
+
+## セットアップ
+
+### 必要環境
+
+- Ruby: TBD
+- Node.js: TBD
+- Rails: TBD
+
+### バックエンド (Rails API)
+
+```bash
+cd backend
+bundle install
+rails db:create db:migrate
+rails s
+```
+
+### フロントエンド (Next.js)
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+## ディレクトリ構成（予定）
+
+```
+readingbook-management/
+├── backend/    # Ruby on Rails (API)
+└── frontend/   # Next.js
+```
+
+## ライセンス
+
+[MIT License](LICENSE)


### PR DESCRIPTION
## Summary
- プロジェクト概要 / 技術スタック (Ruby on Rails + Next.js) / セットアップ手順 / ディレクトリ構成 を記載した README.md を追加
- 詳細未確定の項目は TBD として後続issueで埋めていく前提

## 関連 issue
- #1 Rails APIの初期セットアップ
- #2 Next.jsの初期セットアップ
- #3 DB設計（books / users テーブル）
- #4 認証機能の実装

## Test plan
- [ ] GitHub上でREADMEの表示崩れがないことを確認