### PR TITLE
Add User and Book models with migrations and seeds

### DIFF
--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -10,7 +10,7 @@ gem "puma", ">= 5.0"
 # gem "jbuilder"
 
 # Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
-# gem "bcrypt", "~> 3.1.7"
+gem "bcrypt", "~> 3.1.7"
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: %i[ windows jruby ]

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -77,6 +77,7 @@ GEM
       uri (>= 0.13.1)
     ast (2.4.3)
     base64 (0.3.0)
+    bcrypt (3.1.22)
     bcrypt_pbkdf (1.1.2)
     bcrypt_pbkdf (1.1.2-arm64-darwin)
     bcrypt_pbkdf (1.1.2-x86_64-darwin)
@@ -348,6 +349,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
+  bcrypt (~> 3.1.7)
   bootsnap
   brakeman
   bundler-audit

--- a/backend/app/models/book.rb
+++ b/backend/app/models/book.rb
@@ -1,0 +1,19 @@
+class Book < ApplicationRecord
+  belongs_to :user
+
+  enum :status, { unread: 0, reading: 1, finished: 2 }, default: :unread
+
+  validates :title, presence: true, length: { maximum: 255 }
+  validates :author, length: { maximum: 255 }, allow_blank: true
+  validates :status, presence: true
+  validate :finished_at_only_when_finished
+
+  private
+
+  def finished_at_only_when_finished
+    return if finished_at.blank?
+    return if finished?
+
+    errors.add(:finished_at, :inclusion, message: "は読了状態のときのみ設定できます")
+  end
+end

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -1,0 +1,21 @@
+class User < ApplicationRecord
+  has_secure_password
+
+  has_many :books, dependent: :destroy
+
+  before_save :downcase_email
+
+  validates :email,
+            presence: true,
+            length: { maximum: 255 },
+            format: { with: URI::MailTo::EMAIL_REGEXP },
+            uniqueness: { case_sensitive: false }
+  validates :name, presence: true, length: { maximum: 50 }
+  validates :password, length: { minimum: 8 }, allow_nil: true
+
+  private
+
+  def downcase_email
+    email&.downcase!
+  end
+end

--- a/backend/db/migrate/20260504013617_create_users.rb
+++ b/backend/db/migrate/20260504013617_create_users.rb
@@ -1,0 +1,12 @@
+class CreateUsers < ActiveRecord::Migration[8.1]
+  def change
+    create_table :users do |t|
+      t.string :email, null: false
+      t.string :name, null: false
+      t.string :password_digest, null: false
+
+      t.timestamps
+    end
+    add_index :users, :email, unique: true
+  end
+end

--- a/backend/db/migrate/20260504013634_create_books.rb
+++ b/backend/db/migrate/20260504013634_create_books.rb
@@ -1,0 +1,15 @@
+class CreateBooks < ActiveRecord::Migration[8.1]
+  def change
+    create_table :books do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :title, null: false
+      t.string :author
+      t.integer :status, null: false, default: 0
+      t.datetime :finished_at
+      t.text :memo
+
+      t.timestamps
+    end
+    add_index :books, [:user_id, :status]
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,5 +10,28 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 0) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_04_013634) do
+  create_table "books", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "author"
+    t.datetime "created_at", null: false
+    t.datetime "finished_at"
+    t.text "memo"
+    t.integer "status", default: 0, null: false
+    t.string "title", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.index ["user_id", "status"], name: "index_books_on_user_id_and_status"
+    t.index ["user_id"], name: "index_books_on_user_id"
+  end
+
+  create_table "users", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "email", null: false
+    t.string "name", null: false
+    t.string "password_digest", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email"], name: "index_users_on_email", unique: true
+  end
+
+  add_foreign_key "books", "users"
 end

--- a/backend/db/seeds.rb
+++ b/backend/db/seeds.rb
@@ -1,9 +1,39 @@
-# This file should ensure the existence of records required to run the application in every environment (production,
-# development, test). The code here should be idempotent so that it can be executed at any point in every environment.
-# The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
-#
-# Example:
-#
-#   ["Action", "Comedy", "Drama", "Horror"].each do |genre_name|
-#     MovieGenre.find_or_create_by!(name: genre_name)
-#   end
+# Idempotent seed data for development.
+# Run with: bin/rails db:seed
+
+return unless Rails.env.development?
+
+demo_user = User.find_or_create_by!(email: "demo@example.com") do |user|
+  user.name = "Demo User"
+  user.password = "password1234"
+  user.password_confirmation = "password1234"
+end
+
+books = [
+  {
+    title: "リーダブルコード",
+    author: "Dustin Boswell, Trevor Foucher",
+    status: :finished,
+    finished_at: 1.month.ago,
+    memo: "命名と関数分割の原則が刺さった。"
+  },
+  {
+    title: "ドメイン駆動設計入門",
+    author: "成瀬 允宣",
+    status: :reading,
+    memo: "値オブジェクト / エンティティの章まで読了。"
+  },
+  {
+    title: "達人プログラマー",
+    author: "David Thomas, Andrew Hunt",
+    status: :unread
+  }
+]
+
+books.each do |attrs|
+  demo_user.books.find_or_create_by!(title: attrs[:title]) do |book|
+    book.assign_attributes(attrs)
+  end
+end
+
+Rails.logger.info "Seeded #{User.count} users / #{Book.count} books."

--- a/backend/test/fixtures/books.yml
+++ b/backend/test/fixtures/books.yml
@@ -1,0 +1,17 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user: one
+  title: MyString
+  author: MyString
+  status: 1
+  finished_at: 2026-05-04 01:36:34
+  memo: MyText
+
+two:
+  user: two
+  title: MyString
+  author: MyString
+  status: 1
+  finished_at: 2026-05-04 01:36:34
+  memo: MyText

--- a/backend/test/fixtures/users.yml
+++ b/backend/test/fixtures/users.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  email: MyString
+  name: MyString
+  password_digest: MyString
+
+two:
+  email: MyString
+  name: MyString
+  password_digest: MyString

--- a/backend/test/models/book_test.rb
+++ b/backend/test/models/book_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class BookTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/backend/test/models/user_test.rb
+++ b/backend/test/models/user_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class UserTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## Summary
issue #3 のスキーマ設計に基づき、users / books テーブルとモデルを追加。

### 追加したもの
- **bcrypt** gem を有効化（`has_secure_password` 用）
- **User モデル** (`backend/app/models/user.rb`)
  - `email` (一意・小文字化・format バリデーション)
  - `name` (必須・最大50文字)
  - `password_digest` + `has_secure_password`（パスワード長8文字以上）
  - `has_many :books, dependent: :destroy`
- **Book モデル** (`backend/app/models/book.rb`)
  - `belongs_to :user`
  - `status` enum: `unread` / `reading` / `finished` (default: `unread`)
  - `title` 必須、`author` / `memo` / `finished_at` 任意
  - カスタムバリデーション: `finished_at` は `finished` 状態のときのみ設定可
- **マイグレーション**: `users` と `books` テーブル作成、`books(user_id, status)` 複合インデックス
- **seed**: 開発環境に Demo User（`demo@example.com` / `password1234`）+ 書籍3冊を idempotent に投入

## 動作確認

`docker compose exec backend bundle exec rails runner tmp/check.rb` の結果（PR本文では再掲のみ）:

```
=== Users ===
#1 demo@example.com (name=Demo User) books=3
  authenticate('password1234') => OK
  authenticate('wrong') => FAIL

=== Books ===
#1 [finished] 'リーダブルコード' (Dustin Boswell, Trevor Foucher) finished_at=2026-04-04 ...
#2 [reading] 'ドメイン駆動設計入門' (成瀬 允宣) finished_at= memo=値オブジェクト...
#3 [unread] '達人プログラマー' (David Thomas, Andrew Hunt) finished_at= memo=

=== Validation samples ===
Invalid User errors: ["Email is invalid", "Name can't be blank", "Password is too short (minimum is 8 characters)"]
Invalid Book errors (no title): ["Title can't be blank"]
Invalid Book errors (finished_at on reading): ["Finished at は読了状態のときのみ設定できます"]
```

- ✅ utf8mb4 で日本語が正常に保存・取得できる
- ✅ bcrypt 認証 (`authenticate`) が動作
- ✅ 各種バリデーションが期待通り発火

## 関連 issue
- closes #3

## 残タスク（後続）
- API コントローラの実装（Books CRUD / 認証エンドポイント）→ #4
- RSpec / Minitest によるモデルテスト
- 本番（RDS）環境でのマイグレーション検証

## Test plan
- [ ] `docker compose exec backend bundle exec rails db:migrate:status` で `up` を確認
- [ ] `docker compose exec backend bundle exec rails db:seed` が冪等
- [ ] `User.first.authenticate('password1234')` が真
- [ ] `User.first.books.count == 3`