### PR TITLE
Add JWT-based authentication API (signup / login / logout / me)

### DIFF
--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -12,6 +12,9 @@ gem "puma", ">= 5.0"
 # Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
 gem "bcrypt", "~> 3.1.7"
 
+# JSON Web Token for API authentication
+gem "jwt", "~> 2.8"
+
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: %i[ windows jruby ]
 

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -129,6 +129,8 @@ GEM
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
     json (2.19.4)
+    jwt (2.10.2)
+      base64
     kamal (2.11.0)
       activesupport (>= 7.0)
       base64 (~> 0.2)
@@ -355,6 +357,7 @@ DEPENDENCIES
   bundler-audit
   debug
   image_processing (~> 1.2)
+  jwt (~> 2.8)
   kamal
   mysql2 (~> 0.5)
   puma (>= 5.0)

--- a/backend/app/controllers/api/v1/auth_controller.rb
+++ b/backend/app/controllers/api/v1/auth_controller.rb
@@ -1,0 +1,48 @@
+module Api
+  module V1
+    class AuthController < ApplicationController
+      include Authenticatable
+      skip_before_action :authenticate_user!, only: %i[signup login]
+
+      def signup
+        user = User.new(user_params)
+        if user.save
+          render json: { user: user_response(user), token: issue_token(user) }, status: :created
+        else
+          render json: { errors: user.errors.full_messages }, status: :unprocessable_entity
+        end
+      end
+
+      def login
+        user = User.find_by(email: params[:email]&.downcase)
+        if user&.authenticate(params[:password])
+          render json: { user: user_response(user), token: issue_token(user) }
+        else
+          render json: { error: "Invalid credentials" }, status: :unauthorized
+        end
+      end
+
+      def logout
+        head :no_content
+      end
+
+      def me
+        render json: { user: user_response(current_user) }
+      end
+
+      private
+
+      def user_params
+        params.permit(:name, :email, :password, :password_confirmation)
+      end
+
+      def issue_token(user)
+        JsonWebToken.encode({ user_id: user.id })
+      end
+
+      def user_response(user)
+        { id: user.id, name: user.name, email: user.email }
+      end
+    end
+  end
+end

--- a/backend/app/controllers/concerns/authenticatable.rb
+++ b/backend/app/controllers/concerns/authenticatable.rb
@@ -1,0 +1,27 @@
+module Authenticatable
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :authenticate_user!
+    attr_reader :current_user
+  end
+
+  private
+
+  def authenticate_user!
+    token = bearer_token
+    payload = token && JsonWebToken.decode(token)
+    @current_user = payload && User.find_by(id: payload[:user_id])
+    return if @current_user
+
+    render json: { error: "Unauthorized" }, status: :unauthorized
+  end
+
+  def bearer_token
+    header = request.headers["Authorization"]
+    return unless header
+
+    match = header.match(/\ABearer (.+)\z/)
+    match && match[1]
+  end
+end

--- a/backend/app/services/json_web_token.rb
+++ b/backend/app/services/json_web_token.rb
@@ -1,0 +1,24 @@
+class JsonWebToken
+  ALGORITHM = "HS256".freeze
+  DEFAULT_LIFETIME = 24.hours
+
+  class << self
+    def encode(payload, exp: DEFAULT_LIFETIME.from_now)
+      payload = payload.merge(exp: exp.to_i)
+      JWT.encode(payload, secret, ALGORITHM)
+    end
+
+    def decode(token)
+      decoded, = JWT.decode(token, secret, true, algorithm: ALGORITHM)
+      decoded.with_indifferent_access
+    rescue JWT::DecodeError, JWT::ExpiredSignature
+      nil
+    end
+
+    private
+
+    def secret
+      ENV.fetch("JWT_SECRET") { Rails.application.secret_key_base }
+    end
+  end
+end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -6,6 +6,11 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       get "health" => "health#show"
+
+      post "auth/signup" => "auth#signup"
+      post "auth/login" => "auth#login"
+      delete "auth/logout" => "auth#logout"
+      get "auth/me" => "auth#me"
     end
   end
 end


### PR DESCRIPTION
## Summary
issue #4 の認証機能をJWTベースで最小実装。

### 追加したもの
- **jwt gem** 追加
- **`JsonWebToken` サービス** (`app/services/json_web_token.rb`)
  - HS256 / 24時間有効
  - 秘密鍵は `ENV["JWT_SECRET"]` を優先、無ければ `Rails.application.secret_key_base` にフォールバック
- **`Authenticatable` concern** (`app/controllers/concerns/authenticatable.rb`)
  - `Authorization: Bearer <token>` から JWT を抽出
  - `current_user` をセット、無効/未提供なら 401
- **`Api::V1::AuthController`**
  - `POST /api/v1/auth/signup` — サインアップ → 201 + token
  - `POST /api/v1/auth/login` — ログイン → 200 + token
  - `DELETE /api/v1/auth/logout` — ステートレス → 204（クライアント側でtoken破棄）
  - `GET /api/v1/auth/me` — 認証済みユーザー情報 → 200

## 動作確認

| エンドポイント | 結果 |
|---|---|
| `POST /auth/login` (正) | 200, `{ user, token }` |
| `POST /auth/login` (誤pw) | 401 |
| `GET /auth/me` (token付き) | 200, `{ user }` |
| `GET /auth/me` (token無し) | 401 |
| `POST /auth/signup` (新規) | 201, `{ user, token }` |
| `POST /auth/signup` (重複email) | 422 |
| `DELETE /auth/logout` | 204 |

seed の `demo@example.com` / `password1234` でログイン確認済み。

## 関連 issue
- closes #4

## 残タスク（後続）
- Books コントローラを `Authenticatable` で保護する Books CRUD API
- Next.js 側の認証フロー（ログイン画面 / トークン保存 / 未ログイン時リダイレクト）
- リフレッシュトークン / 失効処理（必要なら）
- リクエストスペック（RSpec or Minitest）

## Test plan
- [ ] `docker compose up -d` 状態で `POST /api/v1/auth/login` が成功して token が返る
- [ ] その token で `GET /api/v1/auth/me` が 200 を返す
- [ ] token 無しで `GET /api/v1/auth/me` が 401
- [ ] `POST /api/v1/auth/signup` で新規ユーザー作成可、重複 email は 422