### PR TITLE
Add Books CRUD API scoped to authenticated user

### DIFF
--- a/backend/app/controllers/api/v1/books_controller.rb
+++ b/backend/app/controllers/api/v1/books_controller.rb
@@ -1,0 +1,67 @@
+module Api
+  module V1
+    class BooksController < ApplicationController
+      include Authenticatable
+
+      before_action :set_book, only: %i[show update destroy]
+
+      def index
+        books = current_user.books
+        if params[:status].present? && Book.statuses.key?(params[:status])
+          books = books.where(status: params[:status])
+        end
+        render json: books.order(updated_at: :desc).map { |book| book_response(book) }
+      end
+
+      def show
+        render json: book_response(@book)
+      end
+
+      def create
+        book = current_user.books.new(book_params)
+        if book.save
+          render json: book_response(book), status: :created
+        else
+          render json: { errors: book.errors.full_messages }, status: :unprocessable_entity
+        end
+      end
+
+      def update
+        if @book.update(book_params)
+          render json: book_response(@book)
+        else
+          render json: { errors: @book.errors.full_messages }, status: :unprocessable_entity
+        end
+      end
+
+      def destroy
+        @book.destroy
+        head :no_content
+      end
+
+      private
+
+      def set_book
+        @book = current_user.books.find_by(id: params[:id])
+        render json: { error: "Not found" }, status: :not_found unless @book
+      end
+
+      def book_params
+        params.permit(:title, :author, :status, :memo, :finished_at)
+      end
+
+      def book_response(book)
+        {
+          id: book.id,
+          title: book.title,
+          author: book.author,
+          status: book.status,
+          memo: book.memo,
+          finished_at: book.finished_at,
+          created_at: book.created_at,
+          updated_at: book.updated_at
+        }
+      end
+    end
+  end
+end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -11,6 +11,8 @@ Rails.application.routes.draw do
       post "auth/login" => "auth#login"
       delete "auth/logout" => "auth#logout"
       get "auth/me" => "auth#me"
+
+      resources :books, only: %i[index show create update destroy]
     end
   end
 end


### PR DESCRIPTION
## Summary
書籍 (`books`) のCRUD APIを実装。すべて認証必須で、`current_user.books` スコープにより他ユーザーのデータには触れられない。

### エンドポイント

| Method | Path | 用途 |
|---|---|---|
| GET | `/api/v1/books` | 自分の書籍一覧（`?status=unread|reading|finished` でフィルタ可） |
| GET | `/api/v1/books/:id` | 単一取得 |
| POST | `/api/v1/books` | 作成 |
| PATCH/PUT | `/api/v1/books/:id` | 更新 |
| DELETE | `/api/v1/books/:id` | 削除 |

すべて `Authorization: Bearer <token>` を要求。

## 動作確認

### CRUD ハッピーパス
| 操作 | 結果 |
|---|---|
| GET /books | 200, 3冊（seed） |
| GET /books?status=reading | 200, 1冊 |
| POST /books | 201 |
| GET /books/:id | 200 |
| PATCH /books/:id (status→finished, finished_at) | 200 |
| DELETE /books/:id | 204 |
| GET /books/:id (削除後) | 404 |

### 認証 / バリデーション / スコープ
| ケース | 結果 |
|---|---|
| GET /books (token無し) | 401 |
| POST /books (title空) | 422 |
| 別ユーザーのbookをGET | 404 |
| 別ユーザーのbookをDELETE | 404 |

→ 他ユーザー資源にアクセスしても 403 ではなく 404 を返す（リソース存在の漏洩を防ぐ）。

## 関連 issue
- #4 を補完（認証ヘッダ必須のリソースエンドポイントを追加）

## 残タスク（後続）
- Next.js 側の認証フロー & books画面（一覧 / 詳細 / 編集）
- 期待する `finished_at` 自動制御（finished状態への切替時に自動セット等）
- ページネーション（書籍が多くなった場合）
- リクエストスペック

## Test plan
- [ ] `POST /api/v1/auth/login` で取得した token で `GET /api/v1/books` が seed の3冊を返す
- [ ] `?status=reading` フィルタが効く
- [ ] CREATE / UPDATE / DELETE が動作
- [ ] 他ユーザーのIDにアクセスしても 404