### PR TITLE
Polish UI with Tailwind CSS v4 and improve edit feedback

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,6 +58,10 @@ services:
       - "3001:3000"
     environment:
       NEXT_PUBLIC_API_URL: http://localhost:3000
+      # Force polling so bind-mount file changes are picked up on Docker for Windows.
+      WATCHPACK_POLLING: "true"
+      CHOKIDAR_USEPOLLING: "true"
+    command: ["bash", "-c", "npm install && npm run dev -- --webpack"]
     tty: true
     stdin_open: true
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,12 +13,28 @@
         "react-dom": "19.2.4"
       },
       "devDependencies": {
+        "@tailwindcss/postcss": "^4.2.4",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "eslint": "^9",
         "eslint-config-next": "16.2.4",
+        "postcss": "^8.5.13",
+        "tailwindcss": "^4.2.4",
         "typescript": "^5"
+      }
+    },
+    "node_modules/@alloc/quick-lru": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1239,6 +1255,277 @@
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@tailwindcss/node": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.4.tgz",
+      "integrity": "sha512-Ai7+yQPxz3ddrDQzFfBKdHEVBg0w3Zl83jnjuwxnZOsnH9pGn93QHQtpU0p/8rYWxvbFZHneni6p1BSLK4DkGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "enhanced-resolve": "^5.19.0",
+        "jiti": "^2.6.1",
+        "lightningcss": "1.32.0",
+        "magic-string": "^0.30.21",
+        "source-map-js": "^1.2.1",
+        "tailwindcss": "4.2.4"
+      }
+    },
+    "node_modules/@tailwindcss/oxide": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.2.4.tgz",
+      "integrity": "sha512-9El/iI069DKDSXwTvB9J4BwdO5JhRrOweGaK25taBAvBXyXqJAX+Jqdvs8r8gKpsI/1m0LeJLyQYTf/WLrBT1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "optionalDependencies": {
+        "@tailwindcss/oxide-android-arm64": "4.2.4",
+        "@tailwindcss/oxide-darwin-arm64": "4.2.4",
+        "@tailwindcss/oxide-darwin-x64": "4.2.4",
+        "@tailwindcss/oxide-freebsd-x64": "4.2.4",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.2.4",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.2.4",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.2.4",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.2.4",
+        "@tailwindcss/oxide-linux-x64-musl": "4.2.4",
+        "@tailwindcss/oxide-wasm32-wasi": "4.2.4",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.2.4",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.2.4"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-android-arm64": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.2.4.tgz",
+      "integrity": "sha512-e7MOr1SAn9U8KlZzPi1ZXGZHeC5anY36qjNwmZv9pOJ8E4Q6jmD1vyEHkQFmNOIN7twGPEMXRHmitN4zCMN03g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-arm64": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.2.4.tgz",
+      "integrity": "sha512-tSC/Kbqpz/5/o/C2sG7QvOxAKqyd10bq+ypZNf+9Fi2TvbVbv1zNpcEptcsU7DPROaSbVgUXmrzKhurFvo5eDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-x64": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.2.4.tgz",
+      "integrity": "sha512-yPyUXn3yO/ufR6+Kzv0t4fCg2qNr90jxXc5QqBpjlPNd0NqyDXcmQb/6weunH/MEDXW5dhyEi+agTDiqa3WsGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-freebsd-x64": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.2.4.tgz",
+      "integrity": "sha512-BoMIB4vMQtZsXdGLVc2z+P9DbETkiopogfWZKbWwM8b/1Vinbs4YcUwo+kM/KeLkX3Ygrf4/PsRndKaYhS8Eiw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.2.4.tgz",
+      "integrity": "sha512-7pIHBLTHYRAlS7V22JNuTh33yLH4VElwKtB3bwchK/UaKUPpQ0lPQiOWcbm4V3WP2I6fNIJ23vABIvoy2izdwA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.2.4.tgz",
+      "integrity": "sha512-+E4wxJ0ZGOzSH325reXTWB48l42i93kQqMvDyz5gqfRzRZ7faNhnmvlV4EPGJU3QJM/3Ab5jhJ5pCRUsKn6OQw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.2.4.tgz",
+      "integrity": "sha512-bBADEGAbo4ASnppIziaQJelekCxdMaxisrk+fB7Thit72IBnALp9K6ffA2G4ruj90G9XRS2VQ6q2bCKbfFV82g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.2.4.tgz",
+      "integrity": "sha512-7Mx25E4WTfnht0TVRTyC00j3i0M+EeFe7wguMDTlX4mRxafznw0CA8WJkFjWYH5BlgELd1kSjuU2JiPnNZbJDA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.2.4.tgz",
+      "integrity": "sha512-2wwJRF7nyhOR0hhHoChc04xngV3iS+akccHTGtz965FwF0up4b2lOdo6kI1EbDaEXKgvcrFBYcYQQ/rrnWFVfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.2.4.tgz",
+      "integrity": "sha512-FQsqApeor8Fo6gUEklzmaa9994orJZZDBAlQpK2Mq+DslRKFJeD6AjHpBQ0kZFQohVr8o85PPh8eOy86VlSCmw==",
+      "bundleDependencies": [
+        "@napi-rs/wasm-runtime",
+        "@emnapi/core",
+        "@emnapi/runtime",
+        "@tybys/wasm-util",
+        "@emnapi/wasi-threads",
+        "tslib"
+      ],
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.8.1",
+        "@emnapi/runtime": "^1.8.1",
+        "@emnapi/wasi-threads": "^1.1.0",
+        "@napi-rs/wasm-runtime": "^1.1.1",
+        "@tybys/wasm-util": "^0.10.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.4.tgz",
+      "integrity": "sha512-L9BXqxC4ToVgwMFqj3pmZRqyHEztulpUJzCxUtLjobMCzTPsGt1Fa9enKbOpY2iIyVtaHNeNvAK8ERP/64sqGQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.2.4.tgz",
+      "integrity": "sha512-ESlKG0EpVJQwRjXDDa9rLvhEAh0mhP1sF7sap9dNZT0yyl9SAG6T7gdP09EH0vIv0UNTlo6jPWyujD6559fZvw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/postcss": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.2.4.tgz",
+      "integrity": "sha512-wgAVj6nUWAolAu8YFvzT2cTBIElWHkjZwFYovF+xsqKsW2ADxM/X2opxj5NsF/qVccAOjRNe8X2IdPzMsWyHTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@alloc/quick-lru": "^5.2.0",
+        "@tailwindcss/node": "4.2.4",
+        "@tailwindcss/oxide": "4.2.4",
+        "postcss": "^8.5.6",
+        "tailwindcss": "4.2.4"
       }
     },
     "node_modules/@tybys/wasm-util": {
@@ -2515,8 +2802,8 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "devOptional": true,
       "license": "Apache-2.0",
-      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -2562,6 +2849,20 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/enhanced-resolve": {
+      "version": "5.21.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.0.tgz",
+      "integrity": "sha512-otxSQPw4lkOZWkHpB3zaEQs6gWYEsmX4xQF68ElXC/TWvGxGMSGOvoNbaLXm6/cS/fSfHtsEdw90y20PCd+sCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.3.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
     },
     "node_modules/es-abstract": {
       "version": "1.24.2",
@@ -3497,6 +3798,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/has-bigints": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
@@ -4107,6 +4415,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/jiti": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
+      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -4234,6 +4552,267 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -4278,6 +4857,16 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/math-intrinsics": {
@@ -4436,6 +5025,34 @@
         "sass": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next/node_modules/postcss": {
+      "version": "8.4.31",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.6",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/node-exports-info": {
@@ -4725,9 +5342,10 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "version": "8.5.13",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
+      "integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -4744,9 +5362,9 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
@@ -5446,6 +6064,27 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.4.tgz",
+      "integrity": "sha512-HhKppgO81FQof5m6TEnuBWCZGgfRAWbaeOaGT00KOy/Pf/j6oUihdvBpA7ltCeAvZpFhW3j0PTclkxsd4IXYDA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tapable": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/tinyglobby": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,11 +14,14 @@
     "react-dom": "19.2.4"
   },
   "devDependencies": {
+    "@tailwindcss/postcss": "^4.2.4",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "eslint": "^9",
     "eslint-config-next": "16.2.4",
+    "postcss": "^8.5.13",
+    "tailwindcss": "^4.2.4",
     "typescript": "^5"
   }
 }

--- a/frontend/postcss.config.mjs
+++ b/frontend/postcss.config.mjs
@@ -1,0 +1,7 @@
+const config = {
+  plugins: {
+    "@tailwindcss/postcss": {},
+  },
+};
+
+export default config;

--- a/frontend/src/app/api-health/page.tsx
+++ b/frontend/src/app/api-health/page.tsx
@@ -38,49 +38,28 @@ export default function ApiHealthPage() {
   }, [fetchHealth]);
 
   return (
-    <main
-      style={{
-        fontFamily: "system-ui, sans-serif",
-        padding: "2rem",
-        maxWidth: 720,
-        margin: "0 auto",
-      }}
-    >
-      <h1>API Health Check</h1>
-      <p>
-        Endpoint: <code>{apiUrl}/api/v1/health</code>
+    <main className="mx-auto w-full max-w-xl px-4 py-8">
+      <h1 className="mb-2 text-2xl font-bold tracking-tight">API Health Check</h1>
+      <p className="mb-4 text-sm text-neutral-600 dark:text-neutral-400">
+        Endpoint:{" "}
+        <code className="rounded bg-neutral-100 px-1.5 py-0.5 text-xs dark:bg-neutral-800">
+          {apiUrl}/api/v1/health
+        </code>
       </p>
       <button
         onClick={fetchHealth}
         disabled={loading}
-        style={{
-          padding: "0.5rem 1rem",
-          cursor: loading ? "wait" : "pointer",
-        }}
+        className="mb-4 inline-flex items-center rounded-md border border-neutral-300 bg-white px-4 py-2 text-sm font-medium shadow-sm transition hover:bg-neutral-50 disabled:cursor-not-allowed disabled:opacity-60 dark:border-neutral-700 dark:bg-neutral-900 dark:hover:bg-neutral-800"
       >
         {loading ? "Loading..." : "Refresh"}
       </button>
       {error && (
-        <pre
-          style={{
-            color: "crimson",
-            padding: "1rem",
-            background: "#fee",
-            marginTop: "1rem",
-            whiteSpace: "pre-wrap",
-          }}
-        >
+        <pre className="rounded-md border border-red-300 bg-red-50 px-3 py-2 text-sm text-red-700 dark:border-red-900 dark:bg-red-950/50 dark:text-red-300">
           Error: {error}
         </pre>
       )}
       {health && (
-        <pre
-          style={{
-            padding: "1rem",
-            background: "#f4f4f4",
-            marginTop: "1rem",
-          }}
-        >
+        <pre className="rounded-md border border-neutral-200 bg-neutral-50 p-4 text-sm dark:border-neutral-800 dark:bg-neutral-900">
           {JSON.stringify(health, null, 2)}
         </pre>
       )}

--- a/frontend/src/app/books/[id]/page.tsx
+++ b/frontend/src/app/books/[id]/page.tsx
@@ -14,6 +14,13 @@ export default function BookDetailPage() {
   const { user, loading: authLoading } = useAuth();
   const [book, setBook] = useState<Book | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
+  const [saved, setSaved] = useState(false);
+
+  useEffect(() => {
+    if (!saved) return;
+    const t = setTimeout(() => setSaved(false), 2500);
+    return () => clearTimeout(t);
+  }, [saved]);
 
   useEffect(() => {
     if (!authLoading && !user) router.replace("/login");
@@ -39,55 +46,80 @@ export default function BookDetailPage() {
     router.push("/books");
   };
 
-  if (authLoading || !user) return <main style={{ padding: "2rem" }}>...</main>;
-  if (loadError)
+  if (authLoading || !user)
+    return <main className="px-4 py-8 text-sm opacity-60">...</main>;
+
+  if (loadError) {
     return (
-      <main style={{ padding: "2rem" }}>
-        <p style={{ color: "crimson" }}>{loadError}</p>
-        <Link href="/books">← 一覧に戻る</Link>
+      <main className="mx-auto w-full max-w-xl px-4 py-8">
+        <p className="rounded-md border border-red-300 bg-red-50 px-3 py-2 text-sm text-red-700 dark:border-red-900 dark:bg-red-950/50 dark:text-red-300">
+          {loadError}
+        </p>
+        <Link
+          href="/books"
+          className="mt-4 inline-block text-sm text-blue-600 hover:text-blue-500"
+        >
+          ← 一覧に戻る
+        </Link>
       </main>
     );
-  if (!book) return <main style={{ padding: "2rem" }}>読み込み中...</main>;
+  }
+
+  if (!book) {
+    return (
+      <main className="px-4 py-8 text-sm opacity-60">読み込み中...</main>
+    );
+  }
 
   return (
-    <main
-      style={{
-        maxWidth: 600,
-        margin: "2rem auto",
-        padding: "0 1rem",
-        fontFamily: "system-ui, sans-serif",
-      }}
-    >
-      <header
-        style={{
-          display: "flex",
-          justifyContent: "space-between",
-          alignItems: "center",
-          marginBottom: "1rem",
-        }}
-      >
-        <h1 style={{ margin: 0 }}>書籍を編集</h1>
-        <Link href="/books">← 一覧</Link>
+    <main className="mx-auto w-full max-w-xl px-4 py-8">
+      <header className="mb-6 flex items-center justify-between">
+        <h1 className="text-2xl font-bold tracking-tight">書籍を編集</h1>
+        <Link
+          href="/books"
+          className="text-sm text-neutral-600 hover:text-neutral-900 dark:text-neutral-300 dark:hover:text-white"
+        >
+          ← 一覧
+        </Link>
       </header>
-      <BookForm
-        initial={bookToValues(book)}
-        submitLabel="更新"
-        onSubmit={async (values) => {
-          const updated = await apiFetch<Book>(`/api/v1/books/${book.id}`, {
-            method: "PATCH",
-            json: valuesToPayload(values),
-          });
-          setBook(updated);
-        }}
-      />
-      <hr style={{ margin: "2rem 0" }} />
-      <button
-        type="button"
-        onClick={handleDelete}
-        style={{ padding: "0.5rem 1rem", color: "crimson" }}
-      >
-        この書籍を削除
-      </button>
+
+      {saved && (
+        <p className="mb-4 rounded-md border border-emerald-300 bg-emerald-50 px-3 py-2 text-sm text-emerald-700 dark:border-emerald-900 dark:bg-emerald-950/50 dark:text-emerald-300">
+          ✓ 保存しました
+        </p>
+      )}
+
+      <div className="rounded-xl border border-black/5 bg-white p-6 shadow-sm dark:border-white/10 dark:bg-neutral-900">
+        <BookForm
+          key={book.updated_at}
+          initial={bookToValues(book)}
+          submitLabel="更新"
+          onSubmit={async (values) => {
+            const updated = await apiFetch<Book>(`/api/v1/books/${book.id}`, {
+              method: "PATCH",
+              json: valuesToPayload(values),
+            });
+            setBook(updated);
+            setSaved(true);
+          }}
+        />
+      </div>
+
+      <div className="mt-8 rounded-xl border border-red-200 bg-red-50/50 p-6 dark:border-red-900/60 dark:bg-red-950/20">
+        <h2 className="mb-2 text-sm font-semibold text-red-700 dark:text-red-300">
+          危険ゾーン
+        </h2>
+        <p className="mb-4 text-sm text-red-600 dark:text-red-400">
+          この操作は元に戻せません。
+        </p>
+        <button
+          type="button"
+          onClick={handleDelete}
+          className="inline-flex items-center rounded-md border border-red-300 bg-white px-4 py-2 text-sm font-semibold text-red-700 shadow-sm transition hover:bg-red-50 dark:border-red-900 dark:bg-red-950/30 dark:text-red-300 dark:hover:bg-red-950/60"
+        >
+          この書籍を削除
+        </button>
+      </div>
     </main>
   );
 }

--- a/frontend/src/app/books/new/page.tsx
+++ b/frontend/src/app/books/new/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useEffect } from "react";
 import { useAuth } from "@/contexts/AuthContext";
@@ -14,28 +15,32 @@ export default function NewBookPage() {
     if (!loading && !user) router.replace("/login");
   }, [loading, user, router]);
 
-  if (loading || !user) return <main style={{ padding: "2rem" }}>...</main>;
+  if (loading || !user)
+    return <main className="px-4 py-8 text-sm opacity-60">...</main>;
 
   return (
-    <main
-      style={{
-        maxWidth: 600,
-        margin: "2rem auto",
-        padding: "0 1rem",
-        fontFamily: "system-ui, sans-serif",
-      }}
-    >
-      <h1>書籍を追加</h1>
-      <BookForm
-        submitLabel="作成"
-        onSubmit={async (values) => {
-          const created = await apiFetch<Book>("/api/v1/books", {
-            method: "POST",
-            json: valuesToPayload(values),
-          });
-          router.push(`/books/${created.id}`);
-        }}
-      />
+    <main className="mx-auto w-full max-w-xl px-4 py-8">
+      <header className="mb-6 flex items-center justify-between">
+        <h1 className="text-2xl font-bold tracking-tight">書籍を追加</h1>
+        <Link
+          href="/books"
+          className="text-sm text-neutral-600 hover:text-neutral-900 dark:text-neutral-300 dark:hover:text-white"
+        >
+          ← 一覧
+        </Link>
+      </header>
+      <div className="rounded-xl border border-black/5 bg-white p-6 shadow-sm dark:border-white/10 dark:bg-neutral-900">
+        <BookForm
+          submitLabel="作成"
+          onSubmit={async (values) => {
+            const created = await apiFetch<Book>("/api/v1/books", {
+              method: "POST",
+              json: valuesToPayload(values),
+            });
+            router.push(`/books/${created.id}`);
+          }}
+        />
+      </div>
     </main>
   );
 }

--- a/frontend/src/app/books/page.tsx
+++ b/frontend/src/app/books/page.tsx
@@ -6,7 +6,6 @@ import { useCallback, useEffect, useState } from "react";
 import { useAuth } from "@/contexts/AuthContext";
 import {
   apiFetch,
-  STATUS_COLOR,
   STATUS_LABEL,
   type Book,
   type BookStatus,
@@ -18,6 +17,12 @@ const STATUS_OPTIONS: ({ value: ""; label: string } | { value: BookStatus; label
   { value: "reading", label: STATUS_LABEL.reading },
   { value: "finished", label: STATUS_LABEL.finished },
 ];
+
+const STATUS_BADGE_CLASS: Record<BookStatus, string> = {
+  unread: "bg-neutral-500 text-white",
+  reading: "bg-blue-600 text-white",
+  finished: "bg-emerald-600 text-white",
+};
 
 export default function BooksPage() {
   const router = useRouter();
@@ -49,37 +54,29 @@ export default function BooksPage() {
   }, [user, filter, fetchBooks]);
 
   if (authLoading || !user) {
-    return <main style={{ padding: "2rem" }}>...</main>;
+    return <main className="px-4 py-8 text-sm opacity-60">...</main>;
   }
 
   return (
-    <main
-      style={{
-        maxWidth: 800,
-        margin: "2rem auto",
-        padding: "0 1rem",
-        fontFamily: "system-ui, sans-serif",
-      }}
-    >
-      <header
-        style={{
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "space-between",
-          marginBottom: "1rem",
-        }}
-      >
-        <h1 style={{ margin: 0 }}>書籍一覧</h1>
-        <Link href="/books/new">
-          <button type="button">新規追加</button>
+    <main className="mx-auto w-full max-w-3xl px-4 py-8">
+      <header className="mb-6 flex items-center justify-between">
+        <h1 className="text-2xl font-bold tracking-tight">書籍一覧</h1>
+        <Link
+          href="/books/new"
+          className="inline-flex items-center rounded-md bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-blue-700"
+        >
+          + 新規追加
         </Link>
       </header>
 
-      <div style={{ marginBottom: "1rem" }}>
-        ステータス:&nbsp;
+      <div className="mb-6 flex items-center gap-2 text-sm">
+        <label className="text-neutral-600 dark:text-neutral-400">
+          ステータス:
+        </label>
         <select
           value={filter}
           onChange={(e) => setFilter(e.target.value as "" | BookStatus)}
+          className="rounded-md border border-neutral-300 bg-white px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-neutral-700 dark:bg-neutral-900"
         >
           {STATUS_OPTIONS.map((opt) => (
             <option key={opt.value} value={opt.value}>
@@ -89,53 +86,46 @@ export default function BooksPage() {
         </select>
       </div>
 
-      {error && <p style={{ color: "crimson" }}>エラー: {error}</p>}
+      {error && (
+        <p className="mb-4 rounded-md border border-red-300 bg-red-50 px-3 py-2 text-sm text-red-700 dark:border-red-900 dark:bg-red-950/50 dark:text-red-300">
+          エラー: {error}
+        </p>
+      )}
+
       {loading ? (
-        <p>読み込み中...</p>
+        <p className="text-sm opacity-60">読み込み中...</p>
       ) : books.length === 0 ? (
-        <p>該当する書籍はありません。</p>
+        <div className="rounded-lg border border-dashed border-neutral-300 px-6 py-12 text-center text-sm text-neutral-500 dark:border-neutral-700 dark:text-neutral-400">
+          該当する書籍はありません。
+        </div>
       ) : (
-        <ul style={{ listStyle: "none", padding: 0 }}>
+        <ul className="space-y-3">
           {books.map((book) => (
-            <li
-              key={book.id}
-              style={{
-                border: "1px solid rgba(128, 128, 128, 0.4)",
-                borderRadius: 6,
-                padding: "0.75rem 1rem",
-                marginBottom: "0.5rem",
-              }}
-            >
+            <li key={book.id}>
               <Link
                 href={`/books/${book.id}`}
-                style={{ textDecoration: "none", color: "inherit" }}
+                className="block rounded-lg border border-black/5 bg-white p-4 shadow-sm transition hover:border-blue-300 hover:shadow-md dark:border-white/10 dark:bg-neutral-900 dark:hover:border-blue-700"
               >
-                <div style={{ display: "flex", justifyContent: "space-between" }}>
-                  <strong>{book.title}</strong>
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0 flex-1">
+                    <h2 className="font-semibold leading-tight">{book.title}</h2>
+                    {book.author && (
+                      <p className="mt-1 text-sm text-neutral-500 dark:text-neutral-400">
+                        {book.author}
+                      </p>
+                    )}
+                    {book.memo && (
+                      <p className="mt-2 line-clamp-2 text-sm text-neutral-700 dark:text-neutral-300">
+                        {book.memo}
+                      </p>
+                    )}
+                  </div>
                   <span
-                    style={{
-                      padding: "0.15rem 0.6rem",
-                      borderRadius: 999,
-                      background: STATUS_COLOR[book.status].bg,
-                      color: STATUS_COLOR[book.status].fg,
-                      fontSize: "0.8rem",
-                      fontWeight: 600,
-                      whiteSpace: "nowrap",
-                    }}
+                    className={`shrink-0 rounded-full px-3 py-0.5 text-xs font-semibold ${STATUS_BADGE_CLASS[book.status]}`}
                   >
                     {STATUS_LABEL[book.status]}
                   </span>
                 </div>
-                {book.author && (
-                  <div style={{ fontSize: "0.85rem", opacity: 0.7 }}>
-                    {book.author}
-                  </div>
-                )}
-                {book.memo && (
-                  <div style={{ fontSize: "0.85rem", marginTop: "0.25rem" }}>
-                    {book.memo}
-                  </div>
-                )}
               </Link>
             </li>
           ))}

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -1,17 +1,30 @@
-:root {
-  --background: #ffffff;
-  --foreground: #171717;
+@import "tailwindcss";
+
+@theme {
+  --color-background: #ffffff;
+  --color-foreground: #171717;
+  --color-surface: #ffffff;
+  --color-surface-muted: #f5f5f5;
+  --color-border: rgba(0, 0, 0, 0.1);
+
+  --color-status-unread: #6c757d;
+  --color-status-reading: #0d6efd;
+  --color-status-finished: #198754;
 }
 
 @media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
+  @theme inline {
+    --color-background: #0a0a0a;
+    --color-foreground: #ededed;
+    --color-surface: #161616;
+    --color-surface-muted: #1f1f1f;
+    --color-border: rgba(255, 255, 255, 0.12);
   }
 }
 
 html {
   height: 100%;
+  color-scheme: light dark;
 }
 
 html,
@@ -24,26 +37,8 @@ body {
   min-height: 100%;
   display: flex;
   flex-direction: column;
-  color: var(--foreground);
-  background: var(--background);
-  font-family: Arial, Helvetica, sans-serif;
+  color: var(--color-foreground);
+  background: var(--color-background);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-}
-
-* {
-  box-sizing: border-box;
-  padding: 0;
-  margin: 0;
-}
-
-a {
-  color: inherit;
-  text-decoration: none;
-}
-
-@media (prefers-color-scheme: dark) {
-  html {
-    color-scheme: dark;
-  }
 }

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -5,6 +5,11 @@ import Link from "next/link";
 import { useEffect, useState } from "react";
 import { useAuth } from "@/contexts/AuthContext";
 
+const fieldClass =
+  "block w-full rounded-md border border-neutral-300 bg-white px-3 py-2 text-sm shadow-sm transition focus:border-transparent focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-neutral-700 dark:bg-neutral-900";
+const labelClass =
+  "block text-sm font-medium text-neutral-700 dark:text-neutral-200";
+
 export default function LoginPage() {
   const router = useRouter();
   const { user, loading, login } = useAuth();
@@ -32,50 +37,54 @@ export default function LoginPage() {
   };
 
   return (
-    <main
-      style={{
-        maxWidth: 400,
-        margin: "3rem auto",
-        padding: "0 1rem",
-        fontFamily: "system-ui, sans-serif",
-      }}
-    >
-      <h1>ログイン</h1>
-      <form
-        onSubmit={handleSubmit}
-        style={{ display: "flex", flexDirection: "column", gap: "0.75rem" }}
-      >
-        <label>
-          メールアドレス
-          <input
-            type="email"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            required
-            style={{ width: "100%", padding: "0.5rem", marginTop: "0.25rem" }}
-          />
-        </label>
-        <label>
-          パスワード
-          <input
-            type="password"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            required
-            minLength={8}
-            style={{ width: "100%", padding: "0.5rem", marginTop: "0.25rem" }}
-          />
-        </label>
-        {error && (
-          <p style={{ color: "crimson", margin: 0 }}>エラー: {error}</p>
-        )}
-        <button type="submit" disabled={submitting} style={{ padding: "0.5rem" }}>
-          {submitting ? "送信中..." : "ログイン"}
-        </button>
-      </form>
-      <p style={{ marginTop: "1rem" }}>
-        アカウント未作成の場合は <Link href="/signup">サインアップ</Link>
-      </p>
+    <main className="flex flex-1 items-center justify-center px-4 py-12">
+      <div className="w-full max-w-sm rounded-xl border border-black/5 bg-white p-8 shadow-sm dark:border-white/10 dark:bg-neutral-900">
+        <h1 className="mb-6 text-2xl font-bold tracking-tight">ログイン</h1>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-1">
+            <label className={labelClass}>メールアドレス</label>
+            <input
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+              className={fieldClass}
+            />
+          </div>
+          <div className="space-y-1">
+            <label className={labelClass}>パスワード</label>
+            <input
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+              minLength={8}
+              className={fieldClass}
+            />
+          </div>
+          {error && (
+            <p className="rounded-md border border-red-300 bg-red-50 px-3 py-2 text-sm text-red-700 dark:border-red-900 dark:bg-red-950/50 dark:text-red-300">
+              エラー: {error}
+            </p>
+          )}
+          <button
+            type="submit"
+            disabled={submitting}
+            className="inline-flex w-full justify-center rounded-md bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:focus:ring-offset-neutral-900"
+          >
+            {submitting ? "送信中..." : "ログイン"}
+          </button>
+        </form>
+        <p className="mt-6 text-center text-sm text-neutral-600 dark:text-neutral-400">
+          アカウント未作成の場合は{" "}
+          <Link
+            href="/signup"
+            className="font-medium text-blue-600 hover:text-blue-500"
+          >
+            サインアップ
+          </Link>
+        </p>
+      </div>
     </main>
   );
 }

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -15,19 +15,23 @@ export default function HomePage() {
   }, [loading, user, router]);
 
   return (
-    <main
-      style={{
-        padding: "2rem",
-        fontFamily: "system-ui, sans-serif",
-        textAlign: "center",
-      }}
-    >
-      <h1>📚 ReadingBook Management</h1>
-      <p>読書記録を管理するアプリです。</p>
-      <p>
-        <Link href="/books">書籍一覧</Link> /{" "}
-        <Link href="/login">ログイン</Link> /{" "}
-        <Link href="/signup">サインアップ</Link>
+    <main className="mx-auto flex w-full max-w-xl flex-1 flex-col items-center justify-center gap-4 px-4 py-12 text-center">
+      <h1 className="text-3xl font-bold tracking-tight">📚 ReadingBook Management</h1>
+      <p className="text-neutral-600 dark:text-neutral-400">
+        読書記録を管理するアプリです。
+      </p>
+      <p className="flex gap-3 text-sm">
+        <Link href="/books" className="text-blue-600 hover:text-blue-500">
+          書籍一覧
+        </Link>
+        <span className="opacity-40">/</span>
+        <Link href="/login" className="text-blue-600 hover:text-blue-500">
+          ログイン
+        </Link>
+        <span className="opacity-40">/</span>
+        <Link href="/signup" className="text-blue-600 hover:text-blue-500">
+          サインアップ
+        </Link>
       </p>
     </main>
   );

--- a/frontend/src/app/signup/page.tsx
+++ b/frontend/src/app/signup/page.tsx
@@ -5,6 +5,11 @@ import Link from "next/link";
 import { useEffect, useState } from "react";
 import { useAuth } from "@/contexts/AuthContext";
 
+const fieldClass =
+  "block w-full rounded-md border border-neutral-300 bg-white px-3 py-2 text-sm shadow-sm transition focus:border-transparent focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-neutral-700 dark:bg-neutral-900";
+const labelClass =
+  "block text-sm font-medium text-neutral-700 dark:text-neutral-200";
+
 export default function SignupPage() {
   const router = useRouter();
   const { user, loading, signup } = useAuth();
@@ -33,61 +38,65 @@ export default function SignupPage() {
   };
 
   return (
-    <main
-      style={{
-        maxWidth: 400,
-        margin: "3rem auto",
-        padding: "0 1rem",
-        fontFamily: "system-ui, sans-serif",
-      }}
-    >
-      <h1>サインアップ</h1>
-      <form
-        onSubmit={handleSubmit}
-        style={{ display: "flex", flexDirection: "column", gap: "0.75rem" }}
-      >
-        <label>
-          名前
-          <input
-            type="text"
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-            required
-            maxLength={50}
-            style={{ width: "100%", padding: "0.5rem", marginTop: "0.25rem" }}
-          />
-        </label>
-        <label>
-          メールアドレス
-          <input
-            type="email"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            required
-            style={{ width: "100%", padding: "0.5rem", marginTop: "0.25rem" }}
-          />
-        </label>
-        <label>
-          パスワード（8文字以上）
-          <input
-            type="password"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            required
-            minLength={8}
-            style={{ width: "100%", padding: "0.5rem", marginTop: "0.25rem" }}
-          />
-        </label>
-        {error && (
-          <p style={{ color: "crimson", margin: 0 }}>エラー: {error}</p>
-        )}
-        <button type="submit" disabled={submitting} style={{ padding: "0.5rem" }}>
-          {submitting ? "送信中..." : "登録"}
-        </button>
-      </form>
-      <p style={{ marginTop: "1rem" }}>
-        既にアカウントをお持ちの場合は <Link href="/login">ログイン</Link>
-      </p>
+    <main className="flex flex-1 items-center justify-center px-4 py-12">
+      <div className="w-full max-w-sm rounded-xl border border-black/5 bg-white p-8 shadow-sm dark:border-white/10 dark:bg-neutral-900">
+        <h1 className="mb-6 text-2xl font-bold tracking-tight">サインアップ</h1>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-1">
+            <label className={labelClass}>名前</label>
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              required
+              maxLength={50}
+              className={fieldClass}
+            />
+          </div>
+          <div className="space-y-1">
+            <label className={labelClass}>メールアドレス</label>
+            <input
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+              className={fieldClass}
+            />
+          </div>
+          <div className="space-y-1">
+            <label className={labelClass}>パスワード（8文字以上）</label>
+            <input
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+              minLength={8}
+              className={fieldClass}
+            />
+          </div>
+          {error && (
+            <p className="rounded-md border border-red-300 bg-red-50 px-3 py-2 text-sm text-red-700 dark:border-red-900 dark:bg-red-950/50 dark:text-red-300">
+              エラー: {error}
+            </p>
+          )}
+          <button
+            type="submit"
+            disabled={submitting}
+            className="inline-flex w-full justify-center rounded-md bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:focus:ring-offset-neutral-900"
+          >
+            {submitting ? "送信中..." : "登録"}
+          </button>
+        </form>
+        <p className="mt-6 text-center text-sm text-neutral-600 dark:text-neutral-400">
+          既にアカウントをお持ちの場合は{" "}
+          <Link
+            href="/login"
+            className="font-medium text-blue-600 hover:text-blue-500"
+          >
+            ログイン
+          </Link>
+        </p>
+      </div>
     </main>
   );
 }

--- a/frontend/src/components/BookForm.tsx
+++ b/frontend/src/components/BookForm.tsx
@@ -8,7 +8,7 @@ export type BookFormValues = {
   author: string;
   status: BookStatus;
   memo: string;
-  finished_at: string; // ISO datetime-local value (yyyy-MM-ddThh:mm)
+  finished_at: string;
 };
 
 const STATUSES: BookStatus[] = ["unread", "reading", "finished"];
@@ -45,6 +45,11 @@ export function valuesToPayload(values: BookFormValues): Record<string, unknown>
         : null,
   };
 }
+
+const fieldClass =
+  "block w-full rounded-md border border-neutral-300 bg-white px-3 py-2 text-sm shadow-sm transition focus:border-transparent focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-neutral-700 dark:bg-neutral-900";
+const labelClass =
+  "block text-sm font-medium text-neutral-700 dark:text-neutral-200";
 
 type Props = {
   initial?: BookFormValues;
@@ -84,37 +89,34 @@ export default function BookForm({ initial, onSubmit, submitLabel }: Props) {
   };
 
   return (
-    <form
-      onSubmit={handleSubmit}
-      style={{ display: "flex", flexDirection: "column", gap: "0.75rem" }}
-    >
-      <label>
-        タイトル
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div className="space-y-1">
+        <label className={labelClass}>タイトル</label>
         <input
           type="text"
           required
           maxLength={255}
           value={values.title}
           onChange={(e) => update("title", e.target.value)}
-          style={{ width: "100%", padding: "0.5rem", marginTop: "0.25rem" }}
+          className={fieldClass}
         />
-      </label>
-      <label>
-        著者
+      </div>
+      <div className="space-y-1">
+        <label className={labelClass}>著者</label>
         <input
           type="text"
           maxLength={255}
           value={values.author}
           onChange={(e) => update("author", e.target.value)}
-          style={{ width: "100%", padding: "0.5rem", marginTop: "0.25rem" }}
+          className={fieldClass}
         />
-      </label>
-      <label>
-        ステータス
+      </div>
+      <div className="space-y-1">
+        <label className={labelClass}>ステータス</label>
         <select
           value={values.status}
           onChange={(e) => update("status", e.target.value as BookStatus)}
-          style={{ width: "100%", padding: "0.5rem", marginTop: "0.25rem" }}
+          className={fieldClass}
         >
           {STATUSES.map((s) => (
             <option key={s} value={s}>
@@ -122,29 +124,37 @@ export default function BookForm({ initial, onSubmit, submitLabel }: Props) {
             </option>
           ))}
         </select>
-      </label>
+      </div>
       {values.status === "finished" && (
-        <label>
-          読了日時
+        <div className="space-y-1">
+          <label className={labelClass}>読了日時</label>
           <input
             type="datetime-local"
             value={values.finished_at}
             onChange={(e) => update("finished_at", e.target.value)}
-            style={{ width: "100%", padding: "0.5rem", marginTop: "0.25rem" }}
+            className={fieldClass}
           />
-        </label>
+        </div>
       )}
-      <label>
-        メモ
+      <div className="space-y-1">
+        <label className={labelClass}>メモ</label>
         <textarea
           rows={4}
           value={values.memo}
           onChange={(e) => update("memo", e.target.value)}
-          style={{ width: "100%", padding: "0.5rem", marginTop: "0.25rem" }}
+          className={fieldClass}
         />
-      </label>
-      {error && <p style={{ color: "crimson", margin: 0 }}>エラー: {error}</p>}
-      <button type="submit" disabled={submitting} style={{ padding: "0.5rem" }}>
+      </div>
+      {error && (
+        <p className="rounded-md border border-red-300 bg-red-50 px-3 py-2 text-sm text-red-700 dark:border-red-900 dark:bg-red-950/50 dark:text-red-300">
+          エラー: {error}
+        </p>
+      )}
+      <button
+        type="submit"
+        disabled={submitting}
+        className="inline-flex w-full justify-center rounded-md bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:focus:ring-offset-neutral-900"
+      >
         {submitting ? "送信中..." : submitLabel}
       </button>
     </form>

--- a/frontend/src/components/Nav.tsx
+++ b/frontend/src/components/Nav.tsx
@@ -14,31 +14,35 @@ export default function Nav() {
   };
 
   return (
-    <nav
-      style={{
-        padding: "0.75rem 1.5rem",
-        borderBottom: "1px solid rgba(128, 128, 128, 0.4)",
-        display: "flex",
-        gap: "1rem",
-        alignItems: "center",
-      }}
-    >
-      <Link href="/" style={{ fontWeight: "bold", textDecoration: "none" }}>
+    <nav className="sticky top-0 z-10 flex items-center gap-4 border-b border-black/10 bg-white/80 px-6 py-3 backdrop-blur dark:border-white/10 dark:bg-neutral-900/80">
+      <Link href="/" className="text-base font-bold tracking-tight">
         📚 ReadingBook
       </Link>
-      <Link href="/books" style={{ textDecoration: "none" }}>
+      <Link
+        href="/books"
+        className="text-sm text-neutral-600 hover:text-neutral-900 dark:text-neutral-300 dark:hover:text-white"
+      >
         書籍一覧
       </Link>
-      <Link href="/api-health" style={{ textDecoration: "none" }}>
+      <Link
+        href="/api-health"
+        className="text-sm text-neutral-600 hover:text-neutral-900 dark:text-neutral-300 dark:hover:text-white"
+      >
         API Health
       </Link>
-      <span style={{ marginLeft: "auto" }}>
+      <div className="ml-auto flex items-center gap-3 text-sm">
         {loading ? (
-          <span style={{ opacity: 0.6 }}>...</span>
+          <span className="opacity-60">...</span>
         ) : user ? (
           <>
-            <span style={{ marginRight: "0.75rem" }}>{user.name}</span>
-            <button onClick={handleLogout} type="button">
+            <span className="text-neutral-600 dark:text-neutral-300">
+              {user.name}
+            </span>
+            <button
+              onClick={handleLogout}
+              type="button"
+              className="rounded-md border border-neutral-300 px-3 py-1 hover:bg-neutral-100 dark:border-neutral-700 dark:hover:bg-neutral-800"
+            >
               ログアウト
             </button>
           </>
@@ -46,16 +50,19 @@ export default function Nav() {
           <>
             <Link
               href="/login"
-              style={{ textDecoration: "none", marginRight: "0.5rem" }}
+              className="rounded-md border border-neutral-300 px-3 py-1 hover:bg-neutral-100 dark:border-neutral-700 dark:hover:bg-neutral-800"
             >
               ログイン
             </Link>
-            <Link href="/signup" style={{ textDecoration: "none" }}>
+            <Link
+              href="/signup"
+              className="rounded-md bg-blue-600 px-3 py-1 text-white hover:bg-blue-700"
+            >
               サインアップ
             </Link>
           </>
         )}
-      </span>
+      </div>
     </nav>
   );
 }


### PR DESCRIPTION
## Summary
インラインスタイルから **Tailwind CSS v4** への移行と、編集画面の保存フィードバック改善。

### 含まれる変更

**Tailwind 導入**
- `tailwindcss@^4` / `@tailwindcss/postcss@^4` / `postcss` を追加
- `postcss.config.mjs` を新規作成
- `globals.css` を `@import "tailwindcss";` + `@theme` トークン（light/dark）に書き換え

**UIリファクタ**
- ナビ: sticky / 半透明 / `backdrop-blur`
- フォーム: 角丸入力欄、focusリング、エラー/サクセスバナー
- 書籍一覧: 影付きカード、ホバーで枠が青に、ステータスバッジを色分けピル
- 書籍編集: フォームをカード内、削除UIを「危険ゾーン」セクションへ分離

**保存フィードバック改善**
- 書籍更新後に **「✓ 保存しました」** バナーを 2.5 秒表示
- `key={book.updated_at}` で BookForm を remount し、保存後の値をフォームに反映

**開発サーバ調整**
- Next.js dev を **Webpack** に切替 (`next dev --webpack`)
- Docker bind mount のファイル変更検知のため `WATCHPACK_POLLING` / `CHOKIDAR_USEPOLLING` を有効化
- Turbopack だと Docker for Windows でファイル変更を拾わないことがあるため

## 動作確認
- ✅ /, /login, /signup, /books, /books/new, /books/[id], /api-health 全画面で Tailwind が効いている
- ✅ ライト/ダーク両モードで配色が破綻しない
- ✅ 編集ページで「更新」を押すと緑バナーが表示され、約2.5秒で消える
- ✅ ファイル編集が即座にブラウザに反映される（hot reload復活）

## 残タスク（後続）
- 共通の Button / Input コンポーネント抽出（同じclass文字列の重複を減らす）
- shadcn/ui 等のコンポーネント集を入れるかの検討
- E2E / コンポーネントテスト

## Test plan
- [ ] `docker compose up -d` 状態で `/login` から書籍編集まで一通り動く
- [ ] 編集→更新で「✓ 保存しました」が一時表示される
- [ ] frontend のソースを編集すると hot reload で即反映される