### PR TITLE
Release: Full-stack Playwright E2E + Next.js API proxy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,6 +163,7 @@ jobs:
       - name: Backend DB setup
         working-directory: backend
         run: |
+          bundle exec rails db:create
           bundle exec rails db:schema:load
           bundle exec rails db:seed
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,15 +89,41 @@ jobs:
         run: npm run test
 
   playwright:
-    name: Frontend Playwright
+    name: Frontend Playwright (full stack)
     runs-on: ubuntu-latest
 
-    defaults:
-      run:
-        working-directory: frontend
+    services:
+      mysql:
+        image: mysql:8.4
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_DATABASE: readingbook_development
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping -h localhost -uroot -proot"
+          --health-interval=5s
+          --health-timeout=5s
+          --health-retries=20
+
+    env:
+      RAILS_ENV: development
+      DATABASE_HOST: 127.0.0.1
+      DATABASE_PORT: "3306"
+      DATABASE_USER: root
+      DATABASE_PASSWORD: root
+      DATABASE_NAME: readingbook_development
+      NEXT_INTERNAL_API_URL: http://localhost:3010
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version-file: backend/.ruby-version
+          bundler-cache: true
+          working-directory: backend
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -106,7 +132,8 @@ jobs:
           cache: npm
           cache-dependency-path: frontend/package-lock.json
 
-      - name: Install dependencies
+      - name: Frontend npm ci
+        working-directory: frontend
         run: npm ci
 
       - name: Cache Playwright browsers
@@ -118,11 +145,45 @@ jobs:
 
       - name: Install Playwright browsers
         if: steps.pw-cache.outputs.cache-hit != 'true'
+        working-directory: frontend
         run: npx playwright install --with-deps chromium
 
-      - name: Install OS deps for Playwright
+      - name: Install Playwright OS deps (cache hit)
         if: steps.pw-cache.outputs.cache-hit == 'true'
+        working-directory: frontend
         run: npx playwright install-deps chromium
 
+      - name: Wait for MySQL
+        run: |
+          for i in {1..30}; do
+            mysqladmin ping -h 127.0.0.1 -uroot -proot && break
+            sleep 1
+          done
+
+      - name: Backend DB setup
+        working-directory: backend
+        run: |
+          bundle exec rails db:schema:load
+          bundle exec rails db:seed
+
+      - name: Start backend (port 3010)
+        working-directory: backend
+        run: |
+          bundle exec rails s -p 3010 -b 127.0.0.1 > /tmp/rails.log 2>&1 &
+          for i in {1..30}; do
+            curl -fs http://localhost:3010/up && break
+            sleep 1
+          done
+          curl -fs http://localhost:3010/up || (cat /tmp/rails.log; exit 1)
+
       - name: Run Playwright
+        working-directory: frontend
         run: npm run e2e
+
+      - name: Upload Playwright report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: frontend/playwright-report/
+          retention-days: 7

--- a/backend/config/environments/development.rb
+++ b/backend/config/environments/development.rb
@@ -3,6 +3,11 @@ require "active_support/core_ext/integer/time"
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
+  # Allow requests proxied from the Next.js dev server inside Docker
+  # (where the upstream Host header is the docker service name).
+  config.hosts << "backend"
+  config.hosts << /\Abackend(:\d+)?\z/
+
   # Make code changes take effect immediately without server restart.
   config.enable_reloading = true
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,7 +57,10 @@ services:
     ports:
       - "3001:3000"
     environment:
-      NEXT_PUBLIC_API_URL: http://localhost:3000
+      # Server-side proxy target used by Next.js rewrites (next.config.ts).
+      # Browser-side requests go to /api/v1/... (relative) and Next.js
+      # forwards them to this target inside the Docker network.
+      NEXT_INTERNAL_API_URL: http://backend:3000
       # Force polling so bind-mount file changes are picked up on Docker for Windows.
       WATCHPACK_POLLING: "true"
       CHOKIDAR_USEPOLLING: "true"

--- a/frontend/Dockerfile.dev
+++ b/frontend/Dockerfile.dev
@@ -1,5 +1,10 @@
 FROM node:22-bookworm
 
+# Pre-install Playwright's chromium and its OS dependencies so E2E works
+# out of the box on container recreate.
+RUN npx -y playwright@1.59.1 install --with-deps chromium \
+    && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 
 EXPOSE 3000

--- a/frontend/e2e/books.spec.ts
+++ b/frontend/e2e/books.spec.ts
@@ -1,0 +1,72 @@
+import { test, expect } from "@playwright/test";
+
+const DEMO_EMAIL = "demo@example.com";
+const DEMO_PASSWORD = "password1234";
+
+async function login(page: import("@playwright/test").Page) {
+  await page.goto("/login");
+  await page.getByLabel("メールアドレス").fill(DEMO_EMAIL);
+  await page.getByLabel("パスワード").fill(DEMO_PASSWORD);
+  await page.getByRole("button", { name: "ログイン" }).click();
+  await page.waitForURL("**/books");
+}
+
+test.describe("Books CRUD", () => {
+  test("login shows the seeded books", async ({ page }) => {
+    await login(page);
+
+    await expect(page.getByRole("heading", { name: "書籍一覧" })).toBeVisible();
+    // Seed inserts these three titles for the demo user.
+    await expect(page.getByText("リーダブルコード")).toBeVisible();
+    await expect(page.getByText("ドメイン駆動設計入門")).toBeVisible();
+    await expect(page.getByText("達人プログラマー")).toBeVisible();
+  });
+
+  test("filter narrows the list by status", async ({ page }) => {
+    await login(page);
+
+    await page.getByLabel("ステータス:").selectOption("reading");
+
+    await expect(page.getByText("ドメイン駆動設計入門")).toBeVisible();
+    await expect(page.getByText("リーダブルコード")).not.toBeVisible();
+  });
+
+  test("create, edit, then delete a book", async ({ page }) => {
+    await login(page);
+
+    const initialTitle = `E2E book ${Date.now()}`;
+    const updatedTitle = `${initialTitle} (updated)`;
+
+    // Create
+    await page.getByRole("link", { name: /新規追加/ }).click();
+    await page.waitForURL("**/books/new");
+    await page.getByLabel("タイトル").fill(initialTitle);
+    await page.getByLabel("著者").fill("E2E Author");
+    await page.getByLabel("メモ").fill("created via Playwright");
+    await page.getByRole("button", { name: "作成" }).click();
+
+    await page.waitForURL(/\/books\/\d+$/);
+    await expect(page.getByRole("heading", { name: "書籍を編集" })).toBeVisible();
+    await expect(page.getByLabel("タイトル")).toHaveValue(initialTitle);
+
+    // Edit
+    await page.getByLabel("タイトル").fill(updatedTitle);
+    await page.getByLabel("ステータス").selectOption("reading");
+    await page.getByRole("button", { name: "更新" }).click();
+    await expect(page.getByText("✓ 保存しました")).toBeVisible();
+
+    // The list page now shows the updated title under "reading".
+    await page.getByRole("link", { name: "← 一覧" }).click();
+    await page.waitForURL("**/books");
+    await page.getByLabel("ステータス:").selectOption("reading");
+    await expect(page.getByText(updatedTitle)).toBeVisible();
+
+    // Delete (auto-confirm the window.confirm dialog)
+    await page.getByText(updatedTitle).click();
+    await page.waitForURL(/\/books\/\d+$/);
+    page.once("dialog", (dialog) => dialog.accept());
+    await page.getByRole("button", { name: /削除/ }).click();
+    await page.waitForURL("**/books");
+    await expect(page.getByText(updatedTitle)).not.toBeVisible();
+  });
+});

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,7 +1,23 @@
 import type { NextConfig } from "next";
 
+// Proxy /api/* and /up to the Rails backend so the browser can use relative
+// paths regardless of where it runs (host browser, dev container, or
+// Playwright inside the dev container).
+const apiTarget = process.env.NEXT_INTERNAL_API_URL ?? "http://localhost:3000";
+
 const nextConfig: NextConfig = {
-  /* config options here */
+  async rewrites() {
+    return [
+      {
+        source: "/api/:path*",
+        destination: `${apiTarget}/api/:path*`,
+      },
+      {
+        source: "/up",
+        destination: `${apiTarget}/up`,
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/frontend/src/app/api-health/page.tsx
+++ b/frontend/src/app/api-health/page.tsx
@@ -11,7 +11,7 @@ type Health = {
   db: string;
 };
 
-const apiUrl = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3000";
+const apiUrl = process.env.NEXT_PUBLIC_API_URL ?? "";
 
 export default function ApiHealthPage() {
   const [health, setHealth] = useState<Health | null>(null);
@@ -43,7 +43,7 @@ export default function ApiHealthPage() {
       <p className="mb-4 text-sm text-neutral-600 dark:text-neutral-400">
         Endpoint:{" "}
         <code className="rounded bg-neutral-100 px-1.5 py-0.5 text-xs dark:bg-neutral-800">
-          {apiUrl}/api/v1/health
+          {apiUrl || ""}/api/v1/health
         </code>
       </p>
       <button

--- a/frontend/src/app/books/page.tsx
+++ b/frontend/src/app/books/page.tsx
@@ -70,10 +70,14 @@ export default function BooksPage() {
       </header>
 
       <div className="mb-6 flex items-center gap-2 text-sm">
-        <label className="text-neutral-600 dark:text-neutral-400">
+        <label
+          htmlFor="status-filter"
+          className="text-neutral-600 dark:text-neutral-400"
+        >
           ステータス:
         </label>
         <select
+          id="status-filter"
           value={filter}
           onChange={(e) => setFilter(e.target.value as "" | BookStatus)}
           className="rounded-md border border-neutral-300 bg-white px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-neutral-700 dark:bg-neutral-900"

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,4 +1,7 @@
-const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3000";
+// Default to relative paths so requests go through the Next.js rewrite proxy
+// configured in next.config.ts. Set NEXT_PUBLIC_API_URL only if you want to
+// hit the Rails server directly (e.g. an external dashboard).
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "";
 const TOKEN_KEY = "readingbook_token";
 
 export function getToken(): string | null {


### PR DESCRIPTION
## Summary
develop に積んだフルスタックE2E化を main に反映。

### 含まれる内容
- **PR #36**: Next.js の rewrites で `/api/*` を Rails にプロキシ。Playwright が CRUD 全フローを実際のバックエンド経由で検証。CI Playwright ジョブも mysql + Rails を立ち上げる構成に拡張。

### CI 状態
PR #36 で 3ジョブすべて pass を確認:
- Backend RSpec: 35s
- Frontend Vitest: 26s
- Frontend Playwright (full stack): 1m43s

## Test plan
- [ ] main 上でも CI が走る
- [ ] 既存機能に変化なし