### PR TITLE
Add Terraform-managed AWS infra: VPC + RDS for MySQL (dev)

### DIFF
--- a/infra/.gitignore
+++ b/infra/.gitignore
@@ -1,0 +1,14 @@
+**/.terraform/
+*.tfstate
+*.tfstate.*
+crash.log
+crash.*.log
+*.tfvars
+*.tfvars.json
+!*.tfvars.example
+.terraformrc
+terraform.rc
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,72 @@
+# infra/
+
+Terraform code for AWS resources backing readingbook-management.
+
+## Layout
+
+```
+infra/
+├── bootstrap/        # one-time: creates the S3 bucket that holds Terraform state for everything else
+├── envs/
+│   └── dev/          # the dev environment (VPC + RDS for now)
+└── modules/
+    ├── vpc/          # VPC, subnets, IGW, optional NAT gateway
+    └── rds/          # RDS for MySQL + parameter group + master password in SSM
+```
+
+State backend: S3 with native lockfile (`use_lockfile = true`, requires Terraform >= 1.10). No DynamoDB.
+
+## Prerequisites
+
+- Terraform >= 1.10
+- AWS CLI authenticated (`aws sts get-caller-identity` succeeds)
+- The IAM principal needs permissions to create VPC, RDS, S3, SSM, and IAM resources used by the modules above
+
+## First-time setup (bootstrap)
+
+The `bootstrap/` workspace creates the state bucket itself, so it uses **local state**. After it's applied once you don't need to touch it again unless the bucket configuration changes.
+
+```sh
+cd infra/bootstrap
+terraform init
+terraform apply
+```
+
+The created bucket is named `readingbook-tf-state-<account-id>`.
+
+## Per-environment apply
+
+```sh
+cd infra/envs/dev
+terraform init
+terraform plan
+terraform apply
+```
+
+`backend.tf` already points at the bootstrap bucket. The first `terraform init` will configure the S3 backend.
+
+## Retrieving the RDS master password
+
+```sh
+aws ssm get-parameter \
+  --name /readingbook-dev/db/master_password \
+  --with-decryption \
+  --query 'Parameter.Value' \
+  --output text
+```
+
+The DB endpoint is in `terraform output rds_endpoint`.
+
+## Connecting to RDS from your laptop
+
+The DB is in private subnets without a public IP. To connect:
+
+- **SSM Session Manager port forwarding** via a small EC2 instance with the SSM agent (recommended, no inbound SG needed)
+- or temporarily attach an EC2 in the same VPC and tunnel through it
+
+We'll add the bastion/SSM piece in a follow-up once it's needed.
+
+## Cost notes
+
+- NAT Gateway is the most expensive single resource here. `enable_nat_gateway` defaults to `false` — flip it on only when ECS/private workloads need outbound internet
+- `db.t4g.micro` + 20 GB gp3 + 7-day backups is the cheapest viable RDS config and is Free Tier eligible for the first 12 months on a new account

--- a/infra/bootstrap/.terraform.lock.hcl
+++ b/infra/bootstrap/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.43.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:bS/rBRbYawLnmFqawh7iJE3qS8ErHInn6FPeepd8Xkw=",
+    "zh:0fe91026ce8c5178781de6773531dcfcf5280ee139059dc5a0c046f1532cf389",
+    "zh:114001f94c38db8702210eda643ec627fa1929a88f774e17db30bc172df6759e",
+    "zh:1fc668d57c7edd81c06f5705b03517393444fe4988a68a3fd90b5b21fed64a55",
+    "zh:2bc0b4d5b706c3bbe7824bcf410942ee631d3423c23f935a51129832d81e1e17",
+    "zh:3f27e2befae3393df2ba423abba7f64c774d8aa6e0de20d00b35d7cca6f47d65",
+    "zh:410bfc19e1f38b7caabc5e1b9cd2de196bdcaa02c840372be26734775ee0214c",
+    "zh:417181a86499386ffbf4d023b9c5219a0d322751513806e977f146f170f0aebc",
+    "zh:6764d31dbae9656b698a3b9d4a44e4267210375ff9bec3e8716bac4450a06f0d",
+    "zh:86401475746c94b12e90b065b76a77c635a84d9cbfc57eace65131c780bd34c6",
+    "zh:98388ac853abbcb18fdf578c18203f485479610d28329c21deefc573976e4b1d",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:afb84c77c569e9979b8287cde33543cff992ca17e62ebe3f2b4a8e69884dbdc5",
+    "zh:c54c64dba350e6856fb8f2813b81d20286a532b02bad5f67da35135c02594407",
+    "zh:d1a46adf1c8f5bf42a1886b06fd25d86981236c933165f0fbc07e4330b77d8d1",
+    "zh:e719e227a676588cdaa5a3e7e3e6b10da26830a566730e8bce2127eec1780f40",
+  ]
+}

--- a/infra/bootstrap/main.tf
+++ b/infra/bootstrap/main.tf
@@ -1,0 +1,68 @@
+provider "aws" {
+  region = var.region
+
+  default_tags {
+    tags = {
+      Project     = "readingbook-management"
+      ManagedBy   = "terraform"
+      Environment = "shared"
+      Component   = "tf-state-backend"
+    }
+  }
+}
+
+data "aws_caller_identity" "current" {}
+
+locals {
+  state_bucket_name = "readingbook-tf-state-${data.aws_caller_identity.current.account_id}"
+}
+
+resource "aws_s3_bucket" "tf_state" {
+  bucket = local.state_bucket_name
+}
+
+resource "aws_s3_bucket_versioning" "tf_state" {
+  bucket = aws_s3_bucket.tf_state.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "tf_state" {
+  bucket = aws_s3_bucket.tf_state.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "tf_state" {
+  bucket = aws_s3_bucket.tf_state.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "tf_state" {
+  bucket = aws_s3_bucket.tf_state.id
+
+  rule {
+    id     = "expire-noncurrent-versions"
+    status = "Enabled"
+
+    filter {}
+
+    noncurrent_version_expiration {
+      noncurrent_days = 90
+    }
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 7
+    }
+  }
+}

--- a/infra/bootstrap/outputs.tf
+++ b/infra/bootstrap/outputs.tf
@@ -1,0 +1,9 @@
+output "tf_state_bucket" {
+  value       = aws_s3_bucket.tf_state.id
+  description = "Name of the S3 bucket holding Terraform state for this project."
+}
+
+output "region" {
+  value       = var.region
+  description = "Region the state bucket lives in."
+}

--- a/infra/bootstrap/variables.tf
+++ b/infra/bootstrap/variables.tf
@@ -1,0 +1,5 @@
+variable "region" {
+  type        = string
+  default     = "ap-northeast-1"
+  description = "AWS region for the Terraform state bucket."
+}

--- a/infra/bootstrap/versions.tf
+++ b/infra/bootstrap/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.10"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}

--- a/infra/envs/dev/.terraform.lock.hcl
+++ b/infra/envs/dev/.terraform.lock.hcl
@@ -1,0 +1,45 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.43.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:bS/rBRbYawLnmFqawh7iJE3qS8ErHInn6FPeepd8Xkw=",
+    "zh:0fe91026ce8c5178781de6773531dcfcf5280ee139059dc5a0c046f1532cf389",
+    "zh:114001f94c38db8702210eda643ec627fa1929a88f774e17db30bc172df6759e",
+    "zh:1fc668d57c7edd81c06f5705b03517393444fe4988a68a3fd90b5b21fed64a55",
+    "zh:2bc0b4d5b706c3bbe7824bcf410942ee631d3423c23f935a51129832d81e1e17",
+    "zh:3f27e2befae3393df2ba423abba7f64c774d8aa6e0de20d00b35d7cca6f47d65",
+    "zh:410bfc19e1f38b7caabc5e1b9cd2de196bdcaa02c840372be26734775ee0214c",
+    "zh:417181a86499386ffbf4d023b9c5219a0d322751513806e977f146f170f0aebc",
+    "zh:6764d31dbae9656b698a3b9d4a44e4267210375ff9bec3e8716bac4450a06f0d",
+    "zh:86401475746c94b12e90b065b76a77c635a84d9cbfc57eace65131c780bd34c6",
+    "zh:98388ac853abbcb18fdf578c18203f485479610d28329c21deefc573976e4b1d",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:afb84c77c569e9979b8287cde33543cff992ca17e62ebe3f2b4a8e69884dbdc5",
+    "zh:c54c64dba350e6856fb8f2813b81d20286a532b02bad5f67da35135c02594407",
+    "zh:d1a46adf1c8f5bf42a1886b06fd25d86981236c933165f0fbc07e4330b77d8d1",
+    "zh:e719e227a676588cdaa5a3e7e3e6b10da26830a566730e8bce2127eec1780f40",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.8.1"
+  constraints = "~> 3.6"
+  hashes = [
+    "h1:osH3aBqEARwOz3VBJKdpFKJJCNIdgRC6k8vPojkLmlY=",
+    "zh:08dd03b918c7b55713026037c5400c48af5b9f468f483463321bd18e17b907b4",
+    "zh:0eee654a5542dc1d41920bbf2419032d6f0d5625b03bd81339e5b33394a3e0ae",
+    "zh:229665ddf060aa0ed315597908483eee5b818a17d09b6417a0f52fd9405c4f57",
+    "zh:2469d2e48f28076254a2a3fc327f184914566d9e40c5780b8d96ebf7205f8bc0",
+    "zh:37d7eb334d9561f335e748280f5535a384a88675af9a9eac439d4cfd663bcb66",
+    "zh:741101426a2f2c52dee37122f0f4a2f2d6af6d852cb1db634480a86398fa3511",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:a902473f08ef8df62cfe6116bd6c157070a93f66622384300de235a533e9d4a9",
+    "zh:b85c511a23e57a2147355932b3b6dce2a11e856b941165793a0c3d7578d94d05",
+    "zh:c5172226d18eaac95b1daac80172287b69d4ce32750c82ad77fa0768be4ea4b8",
+    "zh:dab4434dba34aad569b0bc243c2d3f3ff86dd7740def373f2a49816bd2ff819b",
+    "zh:f49fd62aa8c5525a5c17abd51e27ca5e213881d58882fd42fec4a545b53c9699",
+  ]
+}

--- a/infra/envs/dev/backend.tf
+++ b/infra/envs/dev/backend.tf
@@ -1,0 +1,9 @@
+terraform {
+  backend "s3" {
+    bucket       = "readingbook-tf-state-315826383203"
+    key          = "envs/dev/terraform.tfstate"
+    region       = "ap-northeast-1"
+    encrypt      = true
+    use_lockfile = true
+  }
+}

--- a/infra/envs/dev/main.tf
+++ b/infra/envs/dev/main.tf
@@ -1,0 +1,45 @@
+provider "aws" {
+  region = var.region
+
+  default_tags {
+    tags = {
+      Project     = "readingbook-management"
+      ManagedBy   = "terraform"
+      Environment = var.environment
+    }
+  }
+}
+
+locals {
+  name_prefix = "${var.project}-${var.environment}"
+}
+
+module "vpc" {
+  source = "../../modules/vpc"
+
+  name                 = local.name_prefix
+  vpc_cidr             = var.vpc_cidr
+  availability_zones   = var.availability_zones
+  public_subnet_cidrs  = var.public_subnet_cidrs
+  private_subnet_cidrs = var.private_subnet_cidrs
+  enable_nat_gateway   = var.enable_nat_gateway
+}
+
+module "rds" {
+  source = "../../modules/rds"
+
+  identifier              = local.name_prefix
+  vpc_id                  = module.vpc.vpc_id
+  vpc_cidr_block          = module.vpc.vpc_cidr_block
+  private_subnet_ids      = module.vpc.private_subnet_ids
+  engine_version          = var.db_engine_version
+  parameter_group_family  = var.db_parameter_group_family
+  instance_class          = var.db_instance_class
+  allocated_storage       = var.db_allocated_storage
+  database_name           = var.db_name
+  username                = var.db_username
+  multi_az                = var.db_multi_az
+  deletion_protection     = var.db_deletion_protection
+  skip_final_snapshot     = var.db_skip_final_snapshot
+  backup_retention_period = var.db_backup_retention_period
+}

--- a/infra/envs/dev/outputs.tf
+++ b/infra/envs/dev/outputs.tf
@@ -1,0 +1,32 @@
+output "vpc_id" {
+  value = module.vpc.vpc_id
+}
+
+output "public_subnet_ids" {
+  value = module.vpc.public_subnet_ids
+}
+
+output "private_subnet_ids" {
+  value = module.vpc.private_subnet_ids
+}
+
+output "rds_endpoint" {
+  value = module.rds.endpoint
+}
+
+output "rds_port" {
+  value = module.rds.port
+}
+
+output "rds_database_name" {
+  value = module.rds.database_name
+}
+
+output "rds_username" {
+  value = module.rds.username
+}
+
+output "rds_master_password_parameter_name" {
+  value       = module.rds.master_password_parameter_name
+  description = "Use `aws ssm get-parameter --name <this> --with-decryption` to retrieve the password."
+}

--- a/infra/envs/dev/terraform.tfvars.example
+++ b/infra/envs/dev/terraform.tfvars.example
@@ -1,0 +1,8 @@
+# Copy to terraform.tfvars (gitignored) and edit if you want to override defaults.
+# All variables already have working defaults in variables.tf — this file exists
+# only to document override patterns.
+
+# enable_nat_gateway     = true   # flip on once private workloads (ECS) need outbound
+# db_instance_class      = "db.t4g.small"
+# db_multi_az            = true
+# db_deletion_protection = true

--- a/infra/envs/dev/variables.tf
+++ b/infra/envs/dev/variables.tf
@@ -1,0 +1,89 @@
+variable "project" {
+  type    = string
+  default = "readingbook"
+}
+
+variable "environment" {
+  type    = string
+  default = "dev"
+}
+
+variable "region" {
+  type    = string
+  default = "ap-northeast-1"
+}
+
+variable "vpc_cidr" {
+  type    = string
+  default = "10.0.0.0/16"
+}
+
+variable "availability_zones" {
+  type    = list(string)
+  default = ["ap-northeast-1a", "ap-northeast-1c"]
+}
+
+variable "public_subnet_cidrs" {
+  type    = list(string)
+  default = ["10.0.0.0/24", "10.0.1.0/24"]
+}
+
+variable "private_subnet_cidrs" {
+  type    = list(string)
+  default = ["10.0.10.0/24", "10.0.11.0/24"]
+}
+
+variable "enable_nat_gateway" {
+  type    = bool
+  default = false
+}
+
+variable "db_engine_version" {
+  type    = string
+  default = "8.4.8"
+}
+
+variable "db_parameter_group_family" {
+  type    = string
+  default = "mysql8.4"
+}
+
+variable "db_instance_class" {
+  type    = string
+  default = "db.t4g.micro"
+}
+
+variable "db_allocated_storage" {
+  type    = number
+  default = 20
+}
+
+variable "db_name" {
+  type    = string
+  default = "readingbook"
+}
+
+variable "db_username" {
+  type    = string
+  default = "app_user"
+}
+
+variable "db_multi_az" {
+  type    = bool
+  default = false
+}
+
+variable "db_deletion_protection" {
+  type    = bool
+  default = false
+}
+
+variable "db_skip_final_snapshot" {
+  type    = bool
+  default = true
+}
+
+variable "db_backup_retention_period" {
+  type    = number
+  default = 7
+}

--- a/infra/envs/dev/versions.tf
+++ b/infra/envs/dev/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.10"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.6"
+    }
+  }
+}

--- a/infra/modules/rds/main.tf
+++ b/infra/modules/rds/main.tf
@@ -1,0 +1,109 @@
+resource "random_password" "master" {
+  length           = 32
+  special          = true
+  override_special = "_!@$%^*-=+"
+}
+
+resource "aws_ssm_parameter" "master_password" {
+  name        = "/${var.identifier}/db/master_password"
+  description = "Master password for RDS instance ${var.identifier}"
+  type        = "SecureString"
+  value       = random_password.master.result
+
+  tags = {
+    Name = "${var.identifier}-master-password"
+  }
+}
+
+resource "aws_db_subnet_group" "this" {
+  name       = var.identifier
+  subnet_ids = var.private_subnet_ids
+
+  tags = {
+    Name = var.identifier
+  }
+}
+
+resource "aws_security_group" "db" {
+  name        = "${var.identifier}-db"
+  description = "MySQL access for ${var.identifier}"
+  vpc_id      = var.vpc_id
+
+  tags = {
+    Name = "${var.identifier}-db"
+  }
+}
+
+resource "aws_vpc_security_group_ingress_rule" "mysql_from_vpc" {
+  security_group_id = aws_security_group.db.id
+  description       = "MySQL from within the VPC"
+  cidr_ipv4         = var.vpc_cidr_block
+  ip_protocol       = "tcp"
+  from_port         = 3306
+  to_port           = 3306
+}
+
+resource "aws_vpc_security_group_egress_rule" "all_outbound" {
+  security_group_id = aws_security_group.db.id
+  description       = "All outbound"
+  cidr_ipv4         = "0.0.0.0/0"
+  ip_protocol       = "-1"
+}
+
+resource "aws_db_parameter_group" "this" {
+  name        = "${var.identifier}-mysql"
+  family      = var.parameter_group_family
+  description = "Custom parameters for ${var.identifier}"
+
+  parameter {
+    name  = "character_set_server"
+    value = "utf8mb4"
+  }
+
+  parameter {
+    name  = "collation_server"
+    value = "utf8mb4_unicode_ci"
+  }
+
+  parameter {
+    name  = "time_zone"
+    value = "Asia/Tokyo"
+  }
+}
+
+resource "aws_db_instance" "this" {
+  identifier     = var.identifier
+  engine         = "mysql"
+  engine_version = var.engine_version
+  instance_class = var.instance_class
+
+  allocated_storage     = var.allocated_storage
+  max_allocated_storage = var.allocated_storage * 5
+  storage_type          = "gp3"
+  storage_encrypted     = true
+
+  db_name  = var.database_name
+  username = var.username
+  password = random_password.master.result
+  port     = 3306
+
+  db_subnet_group_name   = aws_db_subnet_group.this.name
+  vpc_security_group_ids = [aws_security_group.db.id]
+  parameter_group_name   = aws_db_parameter_group.this.name
+
+  multi_az            = var.multi_az
+  publicly_accessible = false
+
+  backup_retention_period = var.backup_retention_period
+  backup_window           = var.backup_window
+  maintenance_window      = var.maintenance_window
+
+  deletion_protection       = var.deletion_protection
+  skip_final_snapshot       = var.skip_final_snapshot
+  final_snapshot_identifier = var.skip_final_snapshot ? null : "${var.identifier}-final"
+
+  apply_immediately          = false
+  auto_minor_version_upgrade = true
+
+  performance_insights_enabled = false
+}

--- a/infra/modules/rds/outputs.tf
+++ b/infra/modules/rds/outputs.tf
@@ -1,0 +1,24 @@
+output "endpoint" {
+  value = aws_db_instance.this.address
+}
+
+output "port" {
+  value = aws_db_instance.this.port
+}
+
+output "database_name" {
+  value = aws_db_instance.this.db_name
+}
+
+output "username" {
+  value = aws_db_instance.this.username
+}
+
+output "master_password_parameter_name" {
+  value       = aws_ssm_parameter.master_password.name
+  description = "SSM Parameter Store path holding the master password as SecureString."
+}
+
+output "security_group_id" {
+  value = aws_security_group.db.id
+}

--- a/infra/modules/rds/variables.tf
+++ b/infra/modules/rds/variables.tf
@@ -1,0 +1,81 @@
+variable "identifier" {
+  type        = string
+  description = "RDS instance identifier and prefix for child resources (subnet group, parameter group, SG)."
+}
+
+variable "vpc_id" {
+  type        = string
+  description = "VPC ID the DB subnet group and SG live in."
+}
+
+variable "vpc_cidr_block" {
+  type        = string
+  description = "VPC CIDR. Used for the SG ingress rule allowing MySQL from anywhere inside the VPC."
+}
+
+variable "private_subnet_ids" {
+  type        = list(string)
+  description = "Private subnet IDs (need >=2 across AZs even when multi_az is false — RDS requires the subnet group to span 2 AZs)."
+}
+
+variable "engine_version" {
+  type        = string
+  description = "MySQL engine version. Run `aws rds describe-db-engine-versions --engine mysql` to list available versions."
+}
+
+variable "parameter_group_family" {
+  type        = string
+  description = "RDS parameter group family. Must match the engine major.minor (e.g. mysql8.4)."
+}
+
+variable "instance_class" {
+  type    = string
+  default = "db.t4g.micro"
+}
+
+variable "allocated_storage" {
+  type    = number
+  default = 20
+}
+
+variable "database_name" {
+  type        = string
+  description = "Initial database name created on the instance."
+}
+
+variable "username" {
+  type        = string
+  description = "Master username (avoid reserved names like 'admin' or 'root')."
+  default     = "app_user"
+}
+
+variable "multi_az" {
+  type    = bool
+  default = false
+}
+
+variable "deletion_protection" {
+  type    = bool
+  default = false
+}
+
+variable "skip_final_snapshot" {
+  type    = bool
+  default = true
+}
+
+variable "backup_retention_period" {
+  type    = number
+  default = 7
+}
+
+variable "backup_window" {
+  type        = string
+  default     = "17:00-18:00"
+  description = "UTC. Default = 02:00-03:00 JST."
+}
+
+variable "maintenance_window" {
+  type    = string
+  default = "Sun:18:00-Sun:19:00"
+}

--- a/infra/modules/rds/versions.tf
+++ b/infra/modules/rds/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.10"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.6"
+    }
+  }
+}

--- a/infra/modules/vpc/main.tf
+++ b/infra/modules/vpc/main.tf
@@ -1,0 +1,104 @@
+resource "aws_vpc" "this" {
+  cidr_block           = var.vpc_cidr
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+
+  tags = {
+    Name = var.name
+  }
+}
+
+resource "aws_internet_gateway" "this" {
+  vpc_id = aws_vpc.this.id
+
+  tags = {
+    Name = var.name
+  }
+}
+
+resource "aws_subnet" "public" {
+  count                   = length(var.public_subnet_cidrs)
+  vpc_id                  = aws_vpc.this.id
+  cidr_block              = var.public_subnet_cidrs[count.index]
+  availability_zone       = var.availability_zones[count.index]
+  map_public_ip_on_launch = true
+
+  tags = {
+    Name = "${var.name}-public-${var.availability_zones[count.index]}"
+    Tier = "public"
+  }
+}
+
+resource "aws_subnet" "private" {
+  count             = length(var.private_subnet_cidrs)
+  vpc_id            = aws_vpc.this.id
+  cidr_block        = var.private_subnet_cidrs[count.index]
+  availability_zone = var.availability_zones[count.index]
+
+  tags = {
+    Name = "${var.name}-private-${var.availability_zones[count.index]}"
+    Tier = "private"
+  }
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.this.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.this.id
+  }
+
+  tags = {
+    Name = "${var.name}-public"
+  }
+}
+
+resource "aws_route_table_association" "public" {
+  count          = length(aws_subnet.public)
+  subnet_id      = aws_subnet.public[count.index].id
+  route_table_id = aws_route_table.public.id
+}
+
+resource "aws_eip" "nat" {
+  count  = var.enable_nat_gateway ? 1 : 0
+  domain = "vpc"
+
+  tags = {
+    Name = "${var.name}-nat"
+  }
+}
+
+resource "aws_nat_gateway" "this" {
+  count         = var.enable_nat_gateway ? 1 : 0
+  allocation_id = aws_eip.nat[0].id
+  subnet_id     = aws_subnet.public[0].id
+
+  tags = {
+    Name = "${var.name}-nat"
+  }
+
+  depends_on = [aws_internet_gateway.this]
+}
+
+resource "aws_route_table" "private" {
+  vpc_id = aws_vpc.this.id
+
+  dynamic "route" {
+    for_each = var.enable_nat_gateway ? [1] : []
+    content {
+      cidr_block     = "0.0.0.0/0"
+      nat_gateway_id = aws_nat_gateway.this[0].id
+    }
+  }
+
+  tags = {
+    Name = "${var.name}-private"
+  }
+}
+
+resource "aws_route_table_association" "private" {
+  count          = length(aws_subnet.private)
+  subnet_id      = aws_subnet.private[count.index].id
+  route_table_id = aws_route_table.private.id
+}

--- a/infra/modules/vpc/outputs.tf
+++ b/infra/modules/vpc/outputs.tf
@@ -1,0 +1,23 @@
+output "vpc_id" {
+  value = aws_vpc.this.id
+}
+
+output "vpc_cidr_block" {
+  value = aws_vpc.this.cidr_block
+}
+
+output "public_subnet_ids" {
+  value = aws_subnet.public[*].id
+}
+
+output "private_subnet_ids" {
+  value = aws_subnet.private[*].id
+}
+
+output "internet_gateway_id" {
+  value = aws_internet_gateway.this.id
+}
+
+output "nat_gateway_id" {
+  value = try(aws_nat_gateway.this[0].id, null)
+}

--- a/infra/modules/vpc/variables.tf
+++ b/infra/modules/vpc/variables.tf
@@ -1,0 +1,30 @@
+variable "name" {
+  type        = string
+  description = "Name prefix used for the VPC and its child resources."
+}
+
+variable "vpc_cidr" {
+  type        = string
+  description = "CIDR block for the VPC."
+}
+
+variable "availability_zones" {
+  type        = list(string)
+  description = "AZs to spread subnets across. Must align positionally with the subnet CIDR lists."
+}
+
+variable "public_subnet_cidrs" {
+  type        = list(string)
+  description = "Public subnet CIDRs, one per AZ."
+}
+
+variable "private_subnet_cidrs" {
+  type        = list(string)
+  description = "Private subnet CIDRs, one per AZ."
+}
+
+variable "enable_nat_gateway" {
+  type        = bool
+  default     = false
+  description = "If true, create a single NAT gateway in the first public subnet so private subnets can reach the internet. Costs ~$32/mo + data — leave off until ECS or other private workloads need outbound access."
+}

--- a/infra/modules/vpc/versions.tf
+++ b/infra/modules/vpc/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.10"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
AWS インフラ Phase 1: Terraform でネットワークとデータベースの土台を構築。

- `infra/bootstrap/` — Terraform state 用 S3 バケット（バージョニング/暗号化/パブリックアクセス遮断）
- `infra/envs/dev/` — dev 環境本体、S3 backend + native lockfile (`use_lockfile`、Terraform >= 1.10)
- `infra/modules/vpc/` — VPC、2 AZ の public/private subnet、IGW、NAT GW（オプション）
- `infra/modules/rds/` — MySQL 8.4.8 (db.t4g.micro, gp3 暗号化)、`utf8mb4` / `utf8mb4_unicode_ci`、master password は SSM SecureString

## 構成（dev）
- VPC: `10.0.0.0/16` @ `ap-northeast-1`
- public: `10.0.0.0/24` (1a), `10.0.1.0/24` (1c) — IGW 経由でアウト
- private: `10.0.10.0/24` (1a), `10.0.11.0/24` (1c) — RDS 配置
- RDS: 単一AZ、20GB gp3、バックアップ7日、UTC 17:00-18:00（JST 深夜）
- NAT GW は cost を抑えるため初期は無効。`enable_nat_gateway = true` で有効化可

## 動作確認
- [x] `terraform fmt -recursive`
- [x] `terraform validate`（bootstrap, envs/dev とも success）
- [x] `terraform apply` 成功（account `315826383203`、20 resources added）
- [x] RDS が `available` で起動完了
- [x] SSM Parameter `/readingbook-dev/db/master_password` 作成確認

## 次PR予定（Phase 2）
- ECR リポジトリ
- デプロイ先（App Runner or Fargate）
- NAT GW 有効化
- 踏み台 EC2 + SSM Session Manager（初期 migration / 緊急時用）
- Cost Budget アラート

## 注意
- `infra/envs/dev/backend.tf` の S3 bucket 名にアカウントID `315826383203` をハードコードしている（Terraform backend は変数展開不可のため）。複数アカウント運用時は個別 backend.tf に分離する想定。
- DB master password が必要なときは:
  ```
  aws ssm get-parameter --name /readingbook-dev/db/master_password --with-decryption --query 'Parameter.Value' --output text
  ```

## Test plan
- [ ] レビューア側で `cd infra/envs/dev && terraform init && terraform plan` を実行し、差分なしを確認
- [ ] AWS Console で VPC / RDS / SSM Parameter が想定通り作られているか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)