### PR TITLE
Demo deploy: single-EC2 + URL on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@
 
 読んだ本のタイトル・著者・感想・読了日などを記録し、自分の読書履歴を管理できるWebアプリケーションです。
 
+## デモ
+
+http://54.249.65.144
+
+AWS EC2 上に [Terraform](infra/envs/emergency/) で構築した一時デプロイ環境です（VPC + 単一 EC2 上で docker compose により backend / frontend / MySQL を同居）。動作確認用なので、確認が済み次第 `terraform destroy` で停止します。
+
 ## スクリーンショット
 
 | 書籍一覧 | 書籍を編集 |

--- a/infra/envs/emergency/.terraform.lock.hcl
+++ b/infra/envs/emergency/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.43.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:bS/rBRbYawLnmFqawh7iJE3qS8ErHInn6FPeepd8Xkw=",
+    "zh:0fe91026ce8c5178781de6773531dcfcf5280ee139059dc5a0c046f1532cf389",
+    "zh:114001f94c38db8702210eda643ec627fa1929a88f774e17db30bc172df6759e",
+    "zh:1fc668d57c7edd81c06f5705b03517393444fe4988a68a3fd90b5b21fed64a55",
+    "zh:2bc0b4d5b706c3bbe7824bcf410942ee631d3423c23f935a51129832d81e1e17",
+    "zh:3f27e2befae3393df2ba423abba7f64c774d8aa6e0de20d00b35d7cca6f47d65",
+    "zh:410bfc19e1f38b7caabc5e1b9cd2de196bdcaa02c840372be26734775ee0214c",
+    "zh:417181a86499386ffbf4d023b9c5219a0d322751513806e977f146f170f0aebc",
+    "zh:6764d31dbae9656b698a3b9d4a44e4267210375ff9bec3e8716bac4450a06f0d",
+    "zh:86401475746c94b12e90b065b76a77c635a84d9cbfc57eace65131c780bd34c6",
+    "zh:98388ac853abbcb18fdf578c18203f485479610d28329c21deefc573976e4b1d",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:afb84c77c569e9979b8287cde33543cff992ca17e62ebe3f2b4a8e69884dbdc5",
+    "zh:c54c64dba350e6856fb8f2813b81d20286a532b02bad5f67da35135c02594407",
+    "zh:d1a46adf1c8f5bf42a1886b06fd25d86981236c933165f0fbc07e4330b77d8d1",
+    "zh:e719e227a676588cdaa5a3e7e3e6b10da26830a566730e8bce2127eec1780f40",
+  ]
+}

--- a/infra/envs/emergency/backend.tf
+++ b/infra/envs/emergency/backend.tf
@@ -1,0 +1,9 @@
+terraform {
+  backend "s3" {
+    bucket       = "readingbook-tf-state-315826383203"
+    key          = "envs/emergency/terraform.tfstate"
+    region       = "ap-northeast-1"
+    encrypt      = true
+    use_lockfile = true
+  }
+}

--- a/infra/envs/emergency/main.tf
+++ b/infra/envs/emergency/main.tf
@@ -1,0 +1,222 @@
+provider "aws" {
+  region = var.region
+
+  default_tags {
+    tags = {
+      Project     = "readingbook-management"
+      ManagedBy   = "terraform"
+      Environment = var.environment
+    }
+  }
+}
+
+locals {
+  name_prefix = "${var.project}-${var.environment}"
+}
+
+module "vpc" {
+  source = "../../modules/vpc"
+
+  name                 = local.name_prefix
+  vpc_cidr             = var.vpc_cidr
+  availability_zones   = var.availability_zones
+  public_subnet_cidrs  = var.public_subnet_cidrs
+  private_subnet_cidrs = var.private_subnet_cidrs
+  enable_nat_gateway   = false
+}
+
+data "aws_ami" "al2023" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["al2023-ami-2023*-x86_64"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  filter {
+    name   = "state"
+    values = ["available"]
+  }
+}
+
+resource "aws_iam_role" "ec2" {
+  name = "${local.name_prefix}-ec2"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Principal = {
+        Service = "ec2.amazonaws.com"
+      }
+      Action = "sts:AssumeRole"
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "ssm_core" {
+  role       = aws_iam_role.ec2.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+resource "aws_iam_instance_profile" "ec2" {
+  name = "${local.name_prefix}-ec2"
+  role = aws_iam_role.ec2.name
+}
+
+resource "aws_security_group" "web" {
+  name        = "${local.name_prefix}-web"
+  description = "HTTP access for the demo deployment"
+  vpc_id      = module.vpc.vpc_id
+
+  tags = {
+    Name = "${local.name_prefix}-web"
+  }
+}
+
+resource "aws_vpc_security_group_ingress_rule" "http" {
+  security_group_id = aws_security_group.web.id
+  description       = "HTTP from anywhere"
+  cidr_ipv4         = "0.0.0.0/0"
+  ip_protocol       = "tcp"
+  from_port         = 80
+  to_port           = 80
+}
+
+resource "aws_vpc_security_group_ingress_rule" "frontend_alt" {
+  security_group_id = aws_security_group.web.id
+  description       = "Frontend alt port (Next.js direct)"
+  cidr_ipv4         = "0.0.0.0/0"
+  ip_protocol       = "tcp"
+  from_port         = 3001
+  to_port           = 3001
+}
+
+resource "aws_vpc_security_group_ingress_rule" "backend_direct" {
+  security_group_id = aws_security_group.web.id
+  description       = "Backend direct port for debugging"
+  cidr_ipv4         = "0.0.0.0/0"
+  ip_protocol       = "tcp"
+  from_port         = 3000
+  to_port           = 3000
+}
+
+resource "aws_vpc_security_group_egress_rule" "all_outbound" {
+  security_group_id = aws_security_group.web.id
+  description       = "All outbound"
+  cidr_ipv4         = "0.0.0.0/0"
+  ip_protocol       = "-1"
+}
+
+resource "aws_eip" "web" {
+  domain = "vpc"
+
+  tags = {
+    Name = "${local.name_prefix}-web"
+  }
+}
+
+resource "aws_instance" "web" {
+  ami                    = data.aws_ami.al2023.id
+  instance_type          = var.instance_type
+  subnet_id              = module.vpc.public_subnet_ids[0]
+  vpc_security_group_ids = [aws_security_group.web.id]
+  iam_instance_profile   = aws_iam_instance_profile.ec2.name
+
+  associate_public_ip_address = true
+
+  metadata_options {
+    http_tokens   = "required"
+    http_endpoint = "enabled"
+  }
+
+  root_block_device {
+    volume_size = 20
+    volume_type = "gp3"
+    encrypted   = true
+  }
+
+  user_data_replace_on_change = true
+
+  user_data = <<-EOT
+    #!/bin/bash
+    set -eux
+    exec > >(tee /var/log/user-data.log) 2>&1
+
+    dnf update -y
+    dnf install -y docker git
+    systemctl enable --now docker
+    usermod -aG docker ec2-user
+
+    # Docker Compose plugin
+    DOCKER_CONFIG=/usr/local/lib/docker
+    mkdir -p $DOCKER_CONFIG/cli-plugins
+    curl -SL https://github.com/docker/compose/releases/download/v2.29.7/docker-compose-linux-x86_64 \
+      -o $DOCKER_CONFIG/cli-plugins/docker-compose
+    chmod +x $DOCKER_CONFIG/cli-plugins/docker-compose
+
+    # Get IMDSv2 token + public IPv4
+    TOKEN=$(curl -s -X PUT "http://169.254.169.254/latest/api/token" \
+      -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
+    PUBLIC_IP=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN" \
+      http://169.254.169.254/latest/meta-data/public-ipv4)
+
+    cd /home/ec2-user
+    git clone -b ${var.git_branch} ${var.git_repo_url} app
+    chown -R ec2-user:ec2-user app
+    cd app
+
+    # Generate a random root password (used by the in-container MySQL only)
+    DB_PASS=$(openssl rand -hex 24)
+    cat > .env <<ENV
+    MYSQL_ROOT_PASSWORD=$DB_PASS
+    MYSQL_DATABASE=readingbook_production
+    CORS_ALLOWED_ORIGINS=http://$PUBLIC_IP,http://$PUBLIC_IP:3001
+    ENV
+
+    # Override to publish frontend on port 80
+    cat > docker-compose.override.yml <<COMPOSE
+    services:
+      frontend:
+        ports:
+          - "80:3000"
+          - "3001:3000"
+    COMPOSE
+
+    # Start everything (compose plugin is auto-discovered under /usr/local/lib/docker/cli-plugins)
+    docker compose up -d --build
+
+    # Wait until backend is up enough to accept exec commands.
+    for i in $(seq 1 30); do
+      if docker compose exec -T backend bundle --version >/dev/null 2>&1; then
+        break
+      fi
+      sleep 10
+    done
+
+    # Initialize the database schema and seed data (idempotent enough for fresh boot)
+    docker compose exec -T backend bundle exec rails db:create db:schema:load db:seed || true
+
+    echo "user-data finished at $(date -Is)" >> /var/log/user-data.log
+  EOT
+
+  tags = {
+    Name = "${local.name_prefix}-web"
+  }
+}
+
+resource "aws_eip_association" "web" {
+  instance_id   = aws_instance.web.id
+  allocation_id = aws_eip.web.id
+}

--- a/infra/envs/emergency/outputs.tf
+++ b/infra/envs/emergency/outputs.tf
@@ -1,0 +1,23 @@
+output "public_ip" {
+  value = aws_eip.web.public_ip
+}
+
+output "public_dns" {
+  value = aws_instance.web.public_dns
+}
+
+output "app_url_http" {
+  value = "http://${aws_eip.web.public_ip}"
+}
+
+output "app_url_with_port" {
+  value = "http://${aws_eip.web.public_ip}:3001"
+}
+
+output "ssm_session_command" {
+  value = "aws ssm start-session --target ${aws_instance.web.id}"
+}
+
+output "instance_id" {
+  value = aws_instance.web.id
+}

--- a/infra/envs/emergency/variables.tf
+++ b/infra/envs/emergency/variables.tf
@@ -1,0 +1,49 @@
+variable "project" {
+  type    = string
+  default = "readingbook"
+}
+
+variable "environment" {
+  type    = string
+  default = "emergency"
+}
+
+variable "region" {
+  type    = string
+  default = "ap-northeast-1"
+}
+
+variable "vpc_cidr" {
+  type    = string
+  default = "10.1.0.0/16"
+}
+
+variable "availability_zones" {
+  type    = list(string)
+  default = ["ap-northeast-1a", "ap-northeast-1c"]
+}
+
+variable "public_subnet_cidrs" {
+  type    = list(string)
+  default = ["10.1.0.0/24", "10.1.1.0/24"]
+}
+
+variable "private_subnet_cidrs" {
+  type    = list(string)
+  default = ["10.1.10.0/24", "10.1.11.0/24"]
+}
+
+variable "instance_type" {
+  type    = string
+  default = "t3.medium"
+}
+
+variable "git_repo_url" {
+  type    = string
+  default = "https://github.com/tsuguchi/readingbook-management.git"
+}
+
+variable "git_branch" {
+  type    = string
+  default = "develop"
+}

--- a/infra/envs/emergency/versions.tf
+++ b/infra/envs/emergency/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.10"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
学校課題提出用に、EC2 1台で読書記録アプリの動作環境を立て、その URL を README に追記しました。リポジトリ TOP からデモ環境にアクセスできるように main へ直接マージします。

main は develop に対して PR #40 ぶん遅れていたので、このPRには以下の内容も含まれます:
- **PR #40 由来**: Terraform で AWS インフラ Phase 1（VPC + RDS for MySQL）の構築コード
- **本PR新規**: \`infra/envs/emergency/\`（VPC + 単一 EC2）、README の **デモ** セクション

## デモ環境
🌐 http://54.249.65.144

- **構成**: AWS EC2 (t3.medium, ap-northeast-1a) on VPC (10.1.0.0/16) + Elastic IP + IMDSv2 + SSM 経由でアクセス
- **稼働内容**: docker compose で backend (Rails 8.1.3) / frontend (Next.js 16.2.4 production build) / MySQL 8.4 を同居
- **state**: 既存 S3 バックエンド (\`envs/emergency/...\`) を再利用
- **コスト**: 約 ¥10/時間。動作確認完了後 \`terraform destroy\` で停止予定

## 動作確認
- [x] \`terraform apply\` 成功（23 リソース）
- [x] HTTP 200 で URL 応答
- [x] \`/api/v1/health\` が \`{db: ok}\` を返す
- [x] サインアップ → ログイン → 書籍 CRUD まで通過
- [x] HTML が production build であることを確認

## 後始末
- 課題評価完了後、\`cd infra/envs/emergency && terraform destroy\` で全リソース削除（state バケットだけ残す）

## Test plan
- [ ] 評価者が http://54.249.65.144 にアクセス → サインアップ → ログイン → 本の登録ができる
- [ ] レビュー終了後 destroy

🤖 Generated with [Claude Code](https://claude.com/claude-code)